### PR TITLE
Add methods for batch add and batch add or update, plus ConstructorItem class for easier usage.

### DIFF
--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
@@ -273,7 +273,7 @@ public class ConstructorIO
 	 * @exception ConstructorException if the request is invalid.
 	 */
 	public boolean addOrUpdate(ConstructorItem item, String autocompleteSection) throws ConstructorException {
-		return add(item.getItemName(), autocompleteSection, item.toJsonParams());
+		return addOrUpdate(item.getItemName(), autocompleteSection, item.toJsonParams());
 	}
 
 	/**
@@ -285,7 +285,7 @@ public class ConstructorIO
 	 * @exception ConstructorException if the request is invalid.
 	 */
 	public boolean addOrUpdate(String itemName, String autocompleteSection) throws ConstructorException {
-		return add(itemName, autocompleteSection, null);
+		return addOrUpdate(itemName, autocompleteSection, null);
 	}
 
 	/**
@@ -328,7 +328,7 @@ public class ConstructorIO
 	public boolean addBatch(String autocompleteSection, String... items) throws ConstructorException {
 		ConstructorItem[] citems = new ConstructorItem[items.length];
 		for (int i = 0; i < items.length; i++) citems[i] = new ConstructorItem(items[i]);
-		return addOrUpdateBatch(autocompleteSection, citems);
+		return addBatch(autocompleteSection, citems);
 	}
 	
 	/**

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
@@ -221,8 +221,8 @@ public class ConstructorIO
 	 * @return true if working
 	 * @exception ConstructorException if the request is invalid.
 	 */
-	public boolean add (ConstructorItem item) throws ConstructorException {
-		return add(item.getItemName(), item.getAutocompleteSection(), item.toJsonParams());
+	public boolean add (ConstructorItem item, String autocompleteSection) throws ConstructorException {
+		return add(item.getItemName(), autocompleteSection, item.toJsonParams());
 	}
 
 	/**

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
@@ -277,6 +277,18 @@ public class ConstructorIO
 	/**
 	 * Removes an item from your autocomplete.
 	 *
+	 * @param item the item that you're removing.
+	 * @param autocompleteSection the section of the autocomplete that you're removing the item from.
+	 * @return true if successfully removed
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean remove(ConstructorItem item, String autocompleteSection) throws ConstructorException {
+		remove(item.getItemName(), autocompleteSection);
+	}
+
+	/**
+	 * Removes an item from your autocomplete.
+	 *
 	 * @param itemName the item that you're removing.
 	 * @param autocompleteSection the section of the autocomplete that you're removing the item from.
 	 * @return true if successfully removed
@@ -287,6 +299,58 @@ public class ConstructorIO
 			String url = this.makeUrl("v1/item");
 			String params = ConstructorIO.createItemParams(itemName, autocompleteSection);
 			HttpResponse<JsonNode> jsonRes = Unirest.delete(url)
+																							.basicAuth(this.apiToken, "")
+																							.body(params)
+																							.asJson();
+			return checkResponse(jsonRes, 204);
+		} catch (UnsupportedEncodingException encException) {
+			throw new ConstructorException(encException);
+		} catch (UnirestException uniException) {
+			throw new ConstructorException(uniException);
+		}
+	}
+	
+	/**
+	 * Modifies an item from your autocomplete.
+	 *
+	 * @param oldItem the item that you're modifying.
+	 * @param autocompleteSection the section of the autocomplete that you're modifying the item from.
+	 * @param newItem the new item you want to replace the old one with.
+	 * @return true if successfully modified
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean modify(ConstructorItem oldItem, String autocompleteSection, ConstructorItem newItem) throws ConstructorException {
+		return modify(oldItem.getItemName(), autocompleteSection, newItem);
+	}
+	
+	/**
+	 * Modifies an item from your autocomplete, without renaming it.
+	 *
+	 * @param newItem the item that you're modifying, containing the updated values.
+	 * @param autocompleteSection the section of the autocomplete that you're modifying the item from.
+	 * @return true if successfully modified
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean modify(ConstructorItem newItem, String autocompleteSection) throws ConstructorException {
+		return modify(newItem.getItemName(), autocompleteSection, newItem);
+	}
+	
+	/**
+	 * Modifies an item from your autocomplete.
+	 *
+	 * @param itemName the item that you're modifying.
+	 * @param autocompleteSection the section of the autocomplete that you're modifying the item from.
+	 * @param newItem the new item you want to replace the old one with.
+	 * @return true if successfully modified
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean modify(String itemName, String autocompleteSection, ConstructorItem newItem) throws ConstructorException {
+		try {
+			String url = this.makeUrl("v1/item");
+			newItem.put("new_item_name", newItem.getItemName());
+			newItem.setItemName(itemName);
+			String params = newItem.toJson();
+			HttpResponse<JsonNode> jsonRes = Unirest.put(url)
 																							.basicAuth(this.apiToken, "")
 																							.body(params)
 																							.asJson();

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
@@ -316,6 +316,98 @@ public class ConstructorIO
 			throw new ConstructorException(uniException);
 		}
 	}
+	
+	/**
+	 * Adds multiple items to your autocomplete.
+	 *
+	 * @param autocompleteSection the section of the autocomplete that you're adding the item to.
+	 * @param items the items you want to add.
+	 * @return true if working
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean addBatch(String autocompleteSection, String... items) throws ConstructorException {
+		ConstructorItem[] citems = new ConstructorItem[items.length];
+		for (int i = 0; i < items.length; i++) citems[i] = new ConstructorItem(items[i]);
+		return addOrUpdateBatch(autocompleteSection, citems);
+	}
+	
+	/**
+	 * Adds multiple items to your autocomplete.
+	 *
+	 * @param autocompleteSection the section of the autocomplete that you're adding the item to.
+	 * @param items the items you want to add.
+	 * @return true if working
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean addBatch(String autocompleteSection, ConstructorItem... items) throws ConstructorException {
+		try {
+			String url = this.makeUrl("v1/batch_items");
+			
+			// Build JSON
+			HashMap<String, Object> data = new HashMap<String, Object>();
+			data.put("items", items);
+			data.put("autocomplete_section", autocompleteSection);
+			Gson gson = new Gson();
+			String params = gson.toJson(data);
+			
+			HttpResponse<JsonNode> jsonRes = Unirest.post(url)
+																							.basicAuth(this.apiToken, "")
+																							.body(params)
+																							.asJson();
+			return checkResponse(jsonRes, 204);
+		} catch (UnsupportedEncodingException encException) {
+			throw new ConstructorException(encException);
+		} catch (UnirestException uniException) {
+			throw new ConstructorException(uniException);
+		}
+	}
+	
+	/**
+	 * Adds multiple items to your autocomplete whilst updating existing ones.
+	 *
+	 * @param autocompleteSection the section of the autocomplete that you're adding the item to.
+	 * @param items the items you want to add.
+	 * @return true if working
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean addOrUpdateBatch(String autocompleteSection, String... items) throws ConstructorException {
+		ConstructorItem[] citems = new ConstructorItem[items.length];
+		for (int i = 0; i < items.length; i++) citems[i] = new ConstructorItem(items[i]);
+		return addOrUpdateBatch(autocompleteSection, citems);
+	}
+	
+	/**
+	 * Adds multiple items to your autocomplete whilst updating existing ones.
+	 *
+	 * @param autocompleteSection the section of the autocomplete that you're adding the item to.
+	 * @param items the items you want to add.
+	 * @return true if working
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean addOrUpdateBatch(String autocompleteSection, ConstructorItem... items) throws ConstructorException {
+		try {
+			HashMap<String, String> force = new HashMap<String, String>(2);
+			force.put("force", "1");
+			String url = this.makeUrl("v1/batch_items", force);
+			
+			// Build JSON
+			HashMap<String, Object> data = new HashMap<String, Object>();
+			data.put("items", items);
+			data.put("autocomplete_section", autocompleteSection);
+			Gson gson = new Gson();
+			String params = gson.toJson(data);
+			
+			HttpResponse<JsonNode> jsonRes = Unirest.put(url)
+																							.basicAuth(this.apiToken, "")
+																							.body(params)
+																							.asJson();
+			return checkResponse(jsonRes, 204);
+		} catch (UnsupportedEncodingException encException) {
+			throw new ConstructorException(encException);
+		} catch (UnirestException uniException) {
+			throw new ConstructorException(uniException);
+		}
+	}
 
 	/**
 	 * Removes an item from your autocomplete.

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
@@ -213,6 +213,17 @@ public class ConstructorIO
 			throw new ConstructorException(uniException);
 		}
 	}
+	
+	/**
+	 * Adds an item to your autocomplete.
+	 *
+	 * @param item the item that you're adding.
+	 * @return true if working
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean add (ConstructorItem item) throws ConstructorException {
+		return add(item.getItemName(), item.getAutocompleteSection(), item.toJsonParams());
+	}
 
 	/**
 	 * Adds an item to your autocomplete.

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
@@ -234,7 +234,7 @@ public class ConstructorIO
 	 * @exception ConstructorException if the request is invalid.
 	 */
 	public boolean add (String itemName, String autocompleteSection) throws ConstructorException {
-		add(itemName, autocompleteSection, null);
+		return add(itemName, autocompleteSection, null);
 	}
 
 	/**
@@ -285,7 +285,7 @@ public class ConstructorIO
 	 * @exception ConstructorException if the request is invalid.
 	 */
 	public boolean addOrUpdate(String itemName, String autocompleteSection) throws ConstructorException {
-		add(itemName, autocompleteSection, null);
+		return add(itemName, autocompleteSection, null);
 	}
 
 	/**
@@ -326,7 +326,7 @@ public class ConstructorIO
 	 * @exception ConstructorException if the request is invalid.
 	 */
 	public boolean remove(ConstructorItem item, String autocompleteSection) throws ConstructorException {
-		remove(item.getItemName(), autocompleteSection);
+		return remove(item.getItemName(), autocompleteSection);
 	}
 
 	/**

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorIO.java
@@ -234,19 +234,7 @@ public class ConstructorIO
 	 * @exception ConstructorException if the request is invalid.
 	 */
 	public boolean add (String itemName, String autocompleteSection) throws ConstructorException {
-		try {
-			String url = this.makeUrl("v1/item");
-			String params = ConstructorIO.createItemParams(itemName, autocompleteSection);
-			HttpResponse<JsonNode> jsonRes = Unirest.post(url)
-																							.basicAuth(this.apiToken, "")
-																							.body(params)
-																							.asJson();
-			return checkResponse(jsonRes, 204);
-		} catch (UnsupportedEncodingException encException) {
-			throw new ConstructorException(encException);
-		} catch (UnirestException uniException) {
-			throw new ConstructorException(uniException);
-		}
+		add(itemName, autocompleteSection, null);
 	}
 
 	/**
@@ -261,8 +249,63 @@ public class ConstructorIO
 	public boolean add (String itemName, String autocompleteSection, Map<String, Object> jsonParams) throws ConstructorException {
 		try {
 			String url = this.makeUrl("v1/item");
-			String params = ConstructorIO.createItemParams(itemName, autocompleteSection, jsonParams);
+			String params = (jsonParams == null ?
+											ConstructorIO.createItemParams(itemName, autocompleteSection) :
+											ConstructorIO.createItemParams(itemName, autocompleteSection, jsonParams));
 			HttpResponse<JsonNode> jsonRes = Unirest.post(url)
+																							.basicAuth(this.apiToken, "")
+																							.body(params)
+																							.asJson();
+			return checkResponse(jsonRes, 204);
+		} catch (UnsupportedEncodingException encException) {
+			throw new ConstructorException(encException);
+		} catch (UnirestException uniException) {
+			throw new ConstructorException(uniException);
+		}
+	}
+
+	
+	/**
+	 * Adds an item to your autocomplete or updates it if it already exists.
+	 *
+	 * @param item the item that you're adding.
+	 * @return true if working
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean addOrUpdate(ConstructorItem item, String autocompleteSection) throws ConstructorException {
+		return add(item.getItemName(), autocompleteSection, item.toJsonParams());
+	}
+
+	/**
+	 * Adds an item to your autocomplete or updates it if it already exists.
+	 *
+	 * @param itemName the item that you're adding.
+	 * @param autocompleteSection the section of the autocomplete that you're adding the item to.
+	 * @return true if working
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean addOrUpdate(String itemName, String autocompleteSection) throws ConstructorException {
+		add(itemName, autocompleteSection, null);
+	}
+
+	/**
+	 * Adds an item to your autocomplete or updates it if it already exists.
+	 *
+	 * @param itemName the item that you're adding.
+	 * @param autocompleteSection the section of the autocomplete that you're adding the item to.
+	 * @param jsonParams a map of optional parameters. Optional parameters are in the <a href="https://constructor.io/docs/#add-an-item">API documentation</a>
+	 * @return true if working
+	 * @exception ConstructorException if the request is invalid.
+	 */
+	public boolean addOrUpdate(String itemName, String autocompleteSection, Map<String, Object> jsonParams) throws ConstructorException {
+		try {
+			HashMap<String, String> force = new HashMap<String, String>(2);
+			force.put("force", "1");
+			String url = this.makeUrl("v1/item", force);
+			String params = (jsonParams == null ?
+											ConstructorIO.createItemParams(itemName, autocompleteSection) :
+											ConstructorIO.createItemParams(itemName, autocompleteSection, jsonParams));
+			HttpResponse<JsonNode> jsonRes = Unirest.put(url)
 																							.basicAuth(this.apiToken, "")
 																							.body(params)
 																							.asJson();

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorItem.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorItem.java
@@ -25,14 +25,14 @@ public class ConstructorItem extends HashMap<String, Object> {
 	}
 	
 	/**
-     * Associates the specified value with the specified key in this map.
-     * If the map previously contained a mapping for the key, the old
-     * value is replaced. If the value is null, the field will be removed.
-     *
-     * @param key key with which the specified value is to be associated
-     * @param value value to be associated with the specified key
-     * @return the ConstructorItem itself for chained syntax.
-     */
+	 * Associates the specified value with the specified key in this map.
+	 * If the map previously contained a mapping for the key, the old
+	 * value is replaced. If the value is null, the field will be removed.
+	 *
+	 * @param key key with which the specified value is to be associated
+	 * @param value value to be associated with the specified key
+	 * @return the ConstructorItem itself for chained syntax.
+	 */
 	public ConstructorItem put(String name, Object value) throws IllegalArgumentException {
 		// Check type for known parameters
 		if ((name == "item_name") && value == null) {
@@ -62,11 +62,11 @@ public class ConstructorItem extends HashMap<String, Object> {
 	}
 	
 	/**
-     * Removes the mapping for the specified key from this map if present.
-     *
-     * @param  key key whose mapping is to be removed from the map
-     * @return the ConstructorItem itself for chained syntax.
-     */
+	 * Removes the mapping for the specified key from this map if present.
+	 *
+	 * @param  key key whose mapping is to be removed from the map
+	 * @return the ConstructorItem itself for chained syntax.
+	 */
 	public ConstructorItem remove(String name) throws IllegalArgumentException {
 		if (name == "item_name") {
 			throw new IllegalArgumentException("The field " + name + " cannot be null");

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorItem.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorItem.java
@@ -88,29 +88,31 @@ public class ConstructorItem extends HashMap<String, Object> {
 	
 	
 	
-	public ConstructorItem setItemName(String v) { this.put("item_name", v); return this; }
-	public          String getItemName()  { return (String) this.get("item_name"); }
+	public ConstructorItem setItemName(String v) {         this.put("item_name", v); return this; }
+	public          String getItemName() { return (String) this.get("item_name"); }
 	
 	public ConstructorItem setSuggestedScore(int v) {
 		if (v > 0) super.put("suggested_score", v);
-		else super.remove("suggested_score");
+		else    super.remove("suggested_score");
 		return this;
 	}
-	public             int getSuggestedScore()  { return this.containsKey("suggested_score") ? ((Number) this.get("suggested_score")).intValue() : 0; }
+	public             int getSuggestedScore()  {
+		return this.containsKey("suggested_score") ? ((Number) this.get("suggested_score")).intValue() : 0;
+	}
 	
-	public ConstructorItem setKeywords(String... v) { this.put("keywords", v); return this; }
+	public ConstructorItem setKeywords(String... v) {         this.put("keywords", v); return this; }
 	public        String[] getKeywords()  { return (String[]) this.get("keywords"); }
 	
-	public ConstructorItem setUrl(String v) { this.put("url", v); return this; }
+	public ConstructorItem setUrl(String v) {          this.put("url", v); return this; }
 	public          String getUrl()  { return (String) this.get("url"); }
 	
-	public ConstructorItem setImageUrl(String v) { this.put("image_url", v); return this; }
+	public ConstructorItem setImageUrl(String v) {          this.put("image_url", v); return this; }
 	public          String getImageUrl()  { return (String) this.get("image_url"); }
 	
-	public ConstructorItem setDescription(String v) { this.put("description", v); return this; }
+	public ConstructorItem setDescription(String v) {          this.put("description", v); return this; }
 	public          String getDescription()  { return (String) this.get("description"); }
 	
-	public ConstructorItem setId(String v) { this.put("id", v); return this; }
+	public ConstructorItem setId(String v) {          this.put("id", v); return this; }
 	public          String getId()  { return (String) this.get("id"); }
 	
 }

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorItem.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorItem.java
@@ -1,29 +1,58 @@
+package com.constructor.client;
 import java.util.HashMap;
 import com.google.gson.Gson;
 
 public class ConstructorItem extends HashMap<String, Object> {
 	
-	public ConstructorItem(String itemName, String autocompleteSection, HashMap<String, Object> jsonParams) {
+	/**
+	 * Creates a constructor.io autocomplete item, which is basically a HashMap with additional abstraction.
+	 * @param itemName the item that you're adding.
+	 * @param jsonParams a map of optional parameters. Optional parameters are in the <a href="https://constructor.io/docs/#add-an-item">API documentation</a>
+	 */
+	public ConstructorItem(String itemName, HashMap<String, Object> jsonParams) {
 		super();
 		this.put("item_name", itemName);
-		this.put("autocomplete_section", autocompleteSection);
 		this.putAll(jsonParams);
 	}
 	
-	public ConstructorItem(String itemName, String autocompleteSection) {
-		super();
-		this.put("item_name", itemName);
-		this.put("autocomplete_section", autocompleteSection);
-	}
-	
+	/**
+	 * Creates a constructor.io autocomplete item, which is basically a HashMap with additional abstraction.
+	 * @param itemName the item that you're adding.
+	 */
 	public ConstructorItem(String itemName) {
 		super();
 		this.put("item_name", itemName);
 	}
 	
-	
-	
-	public ConstructorItem put(String name, Object value) {
+	/**
+     * Associates the specified value with the specified key in this map.
+     * If the map previously contained a mapping for the key, the old
+     * value is replaced. If the value is null, the field will be removed.
+     *
+     * @param key key with which the specified value is to be associated
+     * @param value value to be associated with the specified key
+     * @return the ConstructorItem itself for chained syntax.
+     */
+	public ConstructorItem put(String name, Object value) throws IllegalArgumentException {
+		// Check type for known parameters
+		if ((name == "item_name") && value == null) {
+			throw new IllegalArgumentException("The field " + name + " cannot be null");
+		}
+		if ((name == "item_name" || name == "url" || name == "image_url" || name == "description" || name == "id") && !(value instanceof String) && value != null) {
+			throw new IllegalArgumentException("The field " + name + " has to be a String");
+		}
+		if (name == "suggested_score") {
+			if (!(value instanceof Number) && value != null) {
+				throw new IllegalArgumentException("The field " + name + " has to be a Number");
+			}
+			if (value == null) value = 0;
+			// Let setSuggestedScore handle the rest...
+			return setSuggestedScore(((Number) value).intValue());
+		}
+		if ((name == "keywords") && !(value instanceof String[]) && value != null) {
+			throw new IllegalArgumentException("The field " + name + " has to be a String[]");
+		}
+		
 		if (value == null) { // Don't allow null values
 			super.remove(name);
 		} else {
@@ -32,47 +61,56 @@ public class ConstructorItem extends HashMap<String, Object> {
 		return this; // Make it chainable
 	}
 	
-	public String toJson() {
+	/**
+     * Removes the mapping for the specified key from this map if present.
+     *
+     * @param  key key whose mapping is to be removed from the map
+     * @return the ConstructorItem itself for chained syntax.
+     */
+	public ConstructorItem remove(String name) throws IllegalArgumentException {
+		if (name == "item_name") {
+			throw new IllegalArgumentException("The field " + name + " cannot be null");
+		}
+		super.remove(name);
+		return this; // Make it chainable
+	}
+	
+	String toJson() {
 		Gson gson = new Gson();
 		return gson.toJson(this);
 	}
-	public String toJsonParams() {
+	HashMap<String, Object> toJsonParams() {
 		HashMap<String, Object> params = new HashMap<String, Object>();
 		params.putAll(this);
 		params.remove("item_name");
-		params.remove("autocomplete_section");
 		return params; 
 	}
 	
 	
 	
 	public ConstructorItem setItemName(String v) { this.put("item_name", v); return this; }
-	public          String getItemName()  { return this.get("item_name"); }
+	public          String getItemName()  { return (String) this.get("item_name"); }
 	
-	public ConstructorItem setAutocompleteSection(String v) { this.put("autocomplete_section", v); return this; }
-	public          String getAutocompleteSection()  { return this.get("autocomplete_section"); }
-	
-	public ConstructorItem setSuggestedScore(byte v) {
-		if (v != null && (v < 1 || v > 100)) {
-			throw new IndexOutOfBoundsException("suggested_score must be a number between 1-100.");
-		}
-		this.put("suggested_score", v); return this;
+	public ConstructorItem setSuggestedScore(int v) {
+		if (v > 0) super.put("suggested_score", v);
+		else super.remove("suggested_score");
+		return this;
 	}
-	public            byte getSuggestedScore()  { return this.get("suggested_score"); }
+	public             int getSuggestedScore()  { return this.containsKey("suggested_score") ? ((Number) this.get("suggested_score")).intValue() : 0; }
 	
 	public ConstructorItem setKeywords(String... v) { this.put("keywords", v); return this; }
-	public        String[] getKeywords()  { return this.get("keywords"); }
+	public        String[] getKeywords()  { return (String[]) this.get("keywords"); }
 	
 	public ConstructorItem setUrl(String v) { this.put("url", v); return this; }
-	public          String getUrl()  { return this.get("url"); }
+	public          String getUrl()  { return (String) this.get("url"); }
 	
 	public ConstructorItem setImageUrl(String v) { this.put("image_url", v); return this; }
-	public          String getImageUrl()  { return this.get("image_url"); }
+	public          String getImageUrl()  { return (String) this.get("image_url"); }
 	
 	public ConstructorItem setDescription(String v) { this.put("description", v); return this; }
-	public          String getDescription()  { return this.get("description"); }
+	public          String getDescription()  { return (String) this.get("description"); }
 	
 	public ConstructorItem setId(String v) { this.put("id", v); return this; }
-	public          String getId()  { return this.get("id"); }
+	public          String getId()  { return (String) this.get("id"); }
 	
 }

--- a/constructorio-client/src/main/java/com/constructor/client/ConstructorItem.java
+++ b/constructorio-client/src/main/java/com/constructor/client/ConstructorItem.java
@@ -1,0 +1,78 @@
+import java.util.HashMap;
+import com.google.gson.Gson;
+
+public class ConstructorItem extends HashMap<String, Object> {
+	
+	public ConstructorItem(String itemName, String autocompleteSection, HashMap<String, Object> jsonParams) {
+		super();
+		this.put("item_name", itemName);
+		this.put("autocomplete_section", autocompleteSection);
+		this.putAll(jsonParams);
+	}
+	
+	public ConstructorItem(String itemName, String autocompleteSection) {
+		super();
+		this.put("item_name", itemName);
+		this.put("autocomplete_section", autocompleteSection);
+	}
+	
+	public ConstructorItem(String itemName) {
+		super();
+		this.put("item_name", itemName);
+	}
+	
+	
+	
+	public ConstructorItem put(String name, Object value) {
+		if (value == null) { // Don't allow null values
+			super.remove(name);
+		} else {
+			super.put(name, value);
+		}
+		return this; // Make it chainable
+	}
+	
+	public String toJson() {
+		Gson gson = new Gson();
+		return gson.toJson(this);
+	}
+	public String toJsonParams() {
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.putAll(this);
+		params.remove("item_name");
+		params.remove("autocomplete_section");
+		return params; 
+	}
+	
+	
+	
+	public ConstructorItem setItemName(String v) { this.put("item_name", v); return this; }
+	public          String getItemName()  { return this.get("item_name"); }
+	
+	public ConstructorItem setAutocompleteSection(String v) { this.put("autocomplete_section", v); return this; }
+	public          String getAutocompleteSection()  { return this.get("autocomplete_section"); }
+	
+	public ConstructorItem setSuggestedScore(byte v) {
+		if (v != null && (v < 1 || v > 100)) {
+			throw new IndexOutOfBoundsException("suggested_score must be a number between 1-100.");
+		}
+		this.put("suggested_score", v); return this;
+	}
+	public            byte getSuggestedScore()  { return this.get("suggested_score"); }
+	
+	public ConstructorItem setKeywords(String... v) { this.put("keywords", v); return this; }
+	public        String[] getKeywords()  { return this.get("keywords"); }
+	
+	public ConstructorItem setUrl(String v) { this.put("url", v); return this; }
+	public          String getUrl()  { return this.get("url"); }
+	
+	public ConstructorItem setImageUrl(String v) { this.put("image_url", v); return this; }
+	public          String getImageUrl()  { return this.get("image_url"); }
+	
+	public ConstructorItem setDescription(String v) { this.put("description", v); return this; }
+	public          String getDescription()  { return this.get("description"); }
+	
+	public ConstructorItem setId(String v) { this.put("id", v); return this; }
+	public          String getId()  { return this.get("id"); }
+	
+}

--- a/constructorio-client/src/test/java/com/constructor/client/ConstructorTest.java
+++ b/constructorio-client/src/test/java/com/constructor/client/ConstructorTest.java
@@ -2,6 +2,7 @@ package com.constructor.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import java.util.*;
 
 import org.junit.Test;
@@ -69,6 +70,70 @@ public class ConstructorTest {
 		HashMap<String, Object> params = new HashMap<String, Object>();
 		params.put("suggested_score", 1337);
 		assertTrue("addition with params returns alright", constructor.add(randStr, "Search Suggestions", params));
+	}
+	
+	@Test
+	public void addConstructorItemShouldReturn() throws Exception {
+		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
+		String randStr = this.getRandString();
+		assertTrue("addition of a constructor item returns alright", constructor.add(new ConstructorItem(randStr), "Search Suggestions"));
+	}
+	
+	@Test
+	public void addConstructorItemWithHashMapParamsShouldReturn() throws Exception {
+		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
+		String randStr = this.getRandString();
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("suggested_score", 1337);
+		assertTrue("addition of a constructor item with params as a HashMap returns alright", constructor.add(new ConstructorItem(randStr, params), "Search Suggestions"));
+	}
+	
+	@Test
+	public void addConstructorItemWithFunctionParamsShouldReturn() throws Exception {
+		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
+		String randStr = this.getRandString();
+		assertTrue("addition of a constructor item with params set using the functions provided returns alright", constructor.add(new ConstructorItem(randStr).setSuggestedScore(100), "Search Suggestions"));
+	}
+	
+	@Test
+	public void addConstructorItemWithEdgeCasesShouldReturn() throws Exception {
+		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
+		String randStr = this.getRandString();
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("id", "test");
+		assertTrue("addition of a constructor item with some edge cases returns alright", constructor.add(new ConstructorItem("")
+			.setSuggestedScore(1009)
+			.setSuggestedScore(0)
+			.setSuggestedScore(100)
+			.setKeywords("hello", "world")
+			.put("keywords", null)
+			.put("item_name", randStr)
+		, "Search Suggestions"));
+	}
+	
+	@Test
+	public void constructorItem() throws Exception {
+		String randStr = this.getRandString();
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("id", "test");
+		assertEquals("ConstructorItem handles a missing suggested_score correctly", new ConstructorItem(randStr, params)
+			.setSuggestedScore(1009)
+			.setSuggestedScore(0)
+			.get("suggested_score"), null);
+		assertEquals("ConstructorItem handles constructor params correctly", new ConstructorItem(randStr, params)
+			.get("id"), "test");
+		assertEquals("ConstructorItem handles keywords correctly", new ConstructorItem(randStr, params)
+			.setKeywords("hello", "world")
+			.getKeywords()[1], "world");
+		assertEquals("ConstructorItem handles item removal by setting the value to null correctly", new ConstructorItem(randStr, params)
+			.setKeywords(null)
+			.getKeywords(), null);
+		try {
+			new ConstructorItem(randStr, params)
+				.setItemName(null)
+				.getKeywords();
+			fail("ConstructorItem requires an item name to be set");
+		} catch (Exception e) {}
 	}
 	
 	@Test

--- a/constructorio-client/src/test/java/com/constructor/client/ConstructorTest.java
+++ b/constructorio-client/src/test/java/com/constructor/client/ConstructorTest.java
@@ -76,9 +76,7 @@ public class ConstructorTest {
 	public void addOrUpdateShouldReturn() throws Exception {
 		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
 		String randStr = this.getRandString();
-		HashMap<String, Object> params = new HashMap<String, Object>();
-		params.put("suggested_score", 1337);
-		assertTrue("addition with params returns alright", constructor.addOrUpdate(randStr, "Search Suggestions", params));
+		assertTrue("upsert returns alright", constructor.addOrUpdate(randStr, "Search Suggestions"));
 	}
 	
 	@Test
@@ -86,6 +84,18 @@ public class ConstructorTest {
 		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
 		String randStr = this.getRandString();
 		assertTrue("addition of a constructor item returns alright", constructor.add(new ConstructorItem(randStr), "Search Suggestions"));
+	}
+	
+	@Test
+	public void addBatchShouldReturn() throws Exception {
+		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
+		assertTrue("batch addition returns alright", constructor.addBatch("Search Suggestions", new ConstructorItem(this.getRandString()), new ConstructorItem(this.getRandString()), new ConstructorItem(this.getRandString())));
+	}
+	
+	@Test
+	public void addOrUpdateBatchShouldReturn() throws Exception {
+		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
+		assertTrue("batch upsert returns alright", constructor.addOrUpdateBatch("Search Suggestions", new ConstructorItem(this.getRandString()), new ConstructorItem(this.getRandString()), new ConstructorItem(this.getRandString())));
 	}
 	
 	@Test

--- a/constructorio-client/src/test/java/com/constructor/client/ConstructorTest.java
+++ b/constructorio-client/src/test/java/com/constructor/client/ConstructorTest.java
@@ -73,6 +73,15 @@ public class ConstructorTest {
 	}
 	
 	@Test
+	public void addOrUpdateShouldReturn() throws Exception {
+		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
+		String randStr = this.getRandString();
+		HashMap<String, Object> params = new HashMap<String, Object>();
+		params.put("suggested_score", 1337);
+		assertTrue("addition with params returns alright", constructor.addOrUpdate(randStr, "Search Suggestions", params));
+	}
+	
+	@Test
 	public void addConstructorItemShouldReturn() throws Exception {
 		ConstructorIO constructor = new ConstructorIO("YSOxV00F0Kk2R0KnPQN8", "ZqXaOfXuBWD4s3XzCI1q", true, null);
 		String randStr = this.getRandString();


### PR DESCRIPTION
Added some functions and the ConstructorItem class for easier usage, like discussed on CodersClan with Dan. Also includes tests for all added features.

Added the following methods:

```java
public boolean add (ConstructorItem item, String autocompleteSection) throws ConstructorException;
public boolean addOrUpdate(ConstructorItem item, String autocompleteSection) throws ConstructorException;
public boolean addOrUpdate(String itemName, String autocompleteSection) throws ConstructorException;
public boolean addOrUpdate(String itemName, String autocompleteSection, Map<String, Object> jsonParams) throws ConstructorException;
public boolean addBatch(String autocompleteSection, String... items) throws ConstructorException;
public boolean addBatch(String autocompleteSection, ConstructorItem... items) throws ConstructorException;
public boolean addOrUpdateBatch(String autocompleteSection, String... items) throws ConstructorException;
public boolean addOrUpdateBatch(String autocompleteSection, ConstructorItem... items) throws ConstructorException;
public boolean remove(ConstructorItem item, String autocompleteSection) throws ConstructorException;
public boolean modify(ConstructorItem oldItem, String autocompleteSection, ConstructorItem newItem) throws ConstructorException;
public boolean modify(ConstructorItem newItem, String autocompleteSection) throws ConstructorException;
public boolean modify(String itemName, String autocompleteSection, ConstructorItem newItem) throws ConstructorException;
```

Additionally, `add(String itemName, String autocompleteSection, Map<String, Object> jsonParams)` now supports the value `null` for `jsonParams`, which makes the implementation of other functions easier. Please tell me if that behaviour is unwanted.