### PR TITLE
[CH 10275] Add Support for Variations and Sorting in Search/Browse Responses

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -871,7 +871,7 @@ public class ConstructorIO {
             // Move unspecified properties in result data object to metadata object
             for (Object propertyKey : resultData.keySet()) {
                 String propertyName = (String)propertyKey;
-                if (!propertyName.matches("(description|id|url|image_url|groups|facets)")) {
+                if (!propertyName.matches("(description|id|url|image_url|groups|facets|variation_id)")) {
                     metadata.put(propertyName, resultData.get(propertyName));
                 }
             }

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -867,6 +867,12 @@ public class ConstructorIO {
             JSONObject result = results.getJSONObject(i);
             JSONObject resultData = result.getJSONObject("data");
             JSONObject metadata = new JSONObject();
+            
+            // Recursive call to move unspecified properties in result variations to it's metadata object
+            if (!result.isNull("variations")) {
+                JSONArray variations = result.getJSONArray("variations");
+                moveMetadataOutOfResultData(variations);
+            }
 
             // Move unspecified properties in result data object to metadata object
             for (Object propertyKey : resultData.keySet()) {

--- a/constructorio-client/src/main/java/io/constructor/client/models/BrowseResponseInner.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/BrowseResponseInner.java
@@ -21,6 +21,9 @@ public class BrowseResponseInner {
     @SerializedName("total_num_results")
     private Integer totalNumberOfResults;
 
+    @SerializedName("sort_options")
+    private List<FilterSortOption> sortOptions;
+
     /**
      * @return the facets
      */
@@ -47,5 +50,12 @@ public class BrowseResponseInner {
      */
     public Integer getTotalNumberOfResults() {
       return totalNumberOfResults;
+    }
+
+    /**
+     * @return the sort options
+     */
+    public List<FilterSortOption> getSortOptions() {
+      return sortOptions;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/FilterSortOption.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/FilterSortOption.java
@@ -1,0 +1,50 @@
+package io.constructor.client.models;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Constructor.io Sort Option ... uses Gson/Reflection to load data in
+ */
+public class FilterSortOption {
+  
+  @SerializedName("display_name")
+  private String displayName;
+
+  @SerializedName("sort_by")
+  private String sortBy;
+
+  @SerializedName("sort_order")
+  private String sortOrder;
+  
+  @SerializedName("status")
+  private String status;
+
+  /**
+   * @return the display name
+   */
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  /**
+   * @return the sort by
+   */
+  public String getSortBy() {
+    return sortBy;
+  }
+
+  /**
+   * @return the sort order
+   */
+  public String getSortOrder() {
+    return sortOrder;
+  }
+
+  /**
+   * @return the status
+   */
+  public String getStatus() {
+    return status;
+  }
+  
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/Result.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Result.java
@@ -18,6 +18,9 @@ public class Result {
   @SerializedName("matched_terms")
   private List<String> matchedTerms;
 
+  @SerializedName("variations")
+  private List<Result> variations;
+
   /**
    * @return the value
    */
@@ -37,5 +40,12 @@ public class Result {
    */
   public List<String> getMatchedTerms() {
     return matchedTerms;
+  }
+
+  /**
+   * @return the variations
+   */
+  public List<Result> getVariations() {
+    return variations;
   }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/ResultData.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/ResultData.java
@@ -28,6 +28,9 @@ public class ResultData {
   @SerializedName("facets")
   private List<ResultFacet> facets;
 
+  @SerializedName("variation_id")
+  private String variationId;
+
   @SerializedName("metadata")
   private Map<String, Object> metadata;
 
@@ -71,6 +74,13 @@ public class ResultData {
    */
   public List<ResultFacet> getFacets() {
     return facets;
+  }
+
+  /**
+   * @return the variation id
+   */
+  public String getVariationId() {
+    return variationId;
   }
 
   /**

--- a/constructorio-client/src/main/java/io/constructor/client/models/SearchResponseInner.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/SearchResponseInner.java
@@ -10,7 +10,7 @@ import com.google.gson.annotations.SerializedName;
 public class SearchResponseInner {
 
     @SerializedName("facets")
-    List<FilterFacet> facets;
+    private List<FilterFacet> facets;
 
     @SerializedName("groups")
     private List<FilterGroup> groups;
@@ -20,6 +20,9 @@ public class SearchResponseInner {
 
     @SerializedName("total_num_results")
     private Integer totalNumberOfResults;
+
+    @SerializedName("sort_options")
+    private List<FilterSortOption> sortOptions;
 
     /**
      * @return the facets
@@ -47,5 +50,12 @@ public class SearchResponseInner {
      */
     public Integer getTotalNumberOfResults() {
       return totalNumberOfResults;
+    }
+
+    /**
+     * @return the sort options
+     */
+    public List<FilterSortOption> getSortOptions() {
+      return sortOptions;
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -57,14 +57,14 @@ public class ConstructorIOBrowseTest {
 
     @Test
     public void createBrowseResponseShouldReturnAResultWithSortOptions() throws Exception {
-        String string = Utils.getTestResource("response.search.shirt.json");
+        String string = Utils.getTestResource("response.browse.color.blue.json");
         BrowseResponse response = ConstructorIO.createBrowseResponse(string);
-        assertEquals("browse result [sort options] exists", response.getResponse().getSortOptions().size(), 1);
+        assertEquals("browse result [sort options] exists", response.getResponse().getSortOptions().size(), 4);
         assertEquals("browse result sort option [display name] exists", response.getResponse().getSortOptions().get(0).getDisplayName(), "Relevance");
         assertEquals("browse result sort option [sort by] exists", response.getResponse().getSortOptions().get(0).getSortBy(), "relevance");
         assertEquals("browse result sort option [sort order] exists", response.getResponse().getSortOptions().get(0).getSortOrder(), "descending");
         assertEquals("browse result sort option [status] exists", response.getResponse().getSortOptions().get(0).getStatus(), "selected");
-        assertEquals("total number of results", (int) response.getResponse().getTotalNumberOfResults(), 261);
+        assertEquals("total number of results", (int) response.getResponse().getTotalNumberOfResults(), 562);
         assertTrue("browse result id exists", response.getResultId() != null);
     }
 
@@ -128,23 +128,23 @@ public class ConstructorIOBrowseTest {
     }
 
     @Test
-    public void SearchShouldReturnAResultWithVariations() throws Exception {
+    public void BrowseShouldReturnAResultWithVariations() throws Exception {
         ConstructorIO constructor = new ConstructorIO("", "key_dKjn8oS8czBw7Ebv", true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
         BrowseRequest request = new BrowseRequest("Color", "Blue");
         BrowseResponse response = constructor.browse(request, userInfo);
         assertEquals("browse results exist", response.getResponse().getResults().size(), 30);
-        assertEquals("browse result [variations] exists", response.getResponse().getResults().get(0).getVariations().size(), 8);
+        assertEquals("browse result [variations] exists", response.getResponse().getResults().get(0).getVariations().size(), 25);
         assertEquals("browse result variation [facets] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getFacets().size(), 8);
-        assertEquals("browse result variation [value] exists", response.getResponse().getResults().get(0).getVariations().get(0).getValue(), "Coat Aspesi blue");
-        assertEquals("browse result variation [variation id] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getVariationId(), "M0E20000000ECTT");
-        assertEquals("browse result variation [url] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getUrl(), "https://demo.commercetools.com/en/aspesi-coat-I502997385098-blue.html");
+        assertEquals("browse result variation [value] exists", response.getResponse().getResults().get(0).getVariations().get(0).getValue(), "Sneakers ”H222” Hogan light blue");
+        assertEquals("browse result variation [variation id] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getVariationId(), "M0E20000000DVZF");
+        assertEquals("browse result variation [url] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getUrl(), "https://demo.commercetools.com/en/hogan-sneakers-38714173-lightblue.html");
         assertEquals("browse results count as expected", (int) response.getResponse().getTotalNumberOfResults(), 562);
         assertTrue("browse result id exists", response.getResultId() != null);
     }
 
     @Test
-    public void SearchShouldReturnAResultWithSortOptions() throws Exception {
+    public void BrowseShouldReturnAResultWithSortOptions() throws Exception {
         ConstructorIO constructor = new ConstructorIO("", "key_dKjn8oS8czBw7Ebv", true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
         BrowseRequest request = new BrowseRequest("Color", "Blue");

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -34,6 +34,41 @@ public class ConstructorIOBrowseTest {
     }
 
     @Test
+    public void createBrowseResponseShouldReturnAResultWithVariations() throws Exception {
+        String string = Utils.getTestResource("response.browse.color.blue.json");
+        BrowseResponse response = ConstructorIO.createBrowseResponse(string);
+        assertEquals("browse facets exists", response.getResponse().getFacets().size(), 7);
+        assertEquals("browse groups exists", response.getResponse().getGroups().size(), 1);
+        assertEquals("browse results exists", response.getResponse().getResults().size(), 5);
+        assertEquals("browse result [id] exists", response.getResponse().getResults().get(0).getData().getId(), "aspesi-coat-I502997385098-blue");
+        assertEquals("browse result [variation id] exists", response.getResponse().getResults().get(0).getData().getVariationId(), "M0E20000000ECTT");
+        assertEquals("browse result [variations] exists", response.getResponse().getResults().get(0).getVariations().size(), 8);
+        assertEquals("browse result variation [facets] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getFacets().size(), 8);
+        assertEquals("browse result variation [value] exists", response.getResponse().getResults().get(0).getVariations().get(0).getValue(), "Coat Aspesi blue");
+        assertEquals("browse result variation [variation id] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getVariationId(), "M0E20000000ECTT");
+        assertEquals("browse result variation [image url] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getImageUrl(), "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081200_1_large.jpg");
+        assertEquals("browse result variation [url] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getUrl(), "https://demo.commercetools.com/en/aspesi-coat-I502997385098-blue.html");
+        assertTrue("browse result variation [metadata] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getMetadata() != null);
+        assertEquals("browse result variation metadata [product type] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getMetadata().get("productType"), "Outerwear");
+        assertEquals("browse result variation metadata [price] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getMetadata().get("price"), "536.25");
+        assertEquals("total number of results", (int)response.getResponse().getTotalNumberOfResults(), 562);
+        assertTrue("browse result id exists", response.getResultId() != null);
+    }
+
+    @Test
+    public void createBrowseResponseShouldReturnAResultWithSortOptions() throws Exception {
+        String string = Utils.getTestResource("response.search.shirt.json");
+        BrowseResponse response = ConstructorIO.createBrowseResponse(string);
+        assertEquals("browse result [sort options] exists", response.getResponse().getSortOptions().size(), 1);
+        assertEquals("browse result sort option [display name] exists", response.getResponse().getSortOptions().get(0).getDisplayName(), "Relevance");
+        assertEquals("browse result sort option [sort by] exists", response.getResponse().getSortOptions().get(0).getSortBy(), "relevance");
+        assertEquals("browse result sort option [sort order] exists", response.getResponse().getSortOptions().get(0).getSortOrder(), "descending");
+        assertEquals("browse result sort option [status] exists", response.getResponse().getSortOptions().get(0).getStatus(), "selected");
+        assertEquals("total number of results", (int) response.getResponse().getTotalNumberOfResults(), 261);
+        assertTrue("browse result id exists", response.getResultId() != null);
+    }
+
+    @Test
     public void BrowseShouldReturnAResult() throws Exception {
         ConstructorIO constructor = new ConstructorIO("", "key_dKjn8oS8czBw7Ebv", true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
@@ -89,6 +124,37 @@ public class ConstructorIOBrowseTest {
         BrowseResponse response = constructor.browse(request, userInfo);
         assertEquals("browse results exist", response.getResponse().getResults().size(), 17);
         assertEquals("browse results count as expected", (int)response.getResponse().getTotalNumberOfResults(), 17);
+        assertTrue("browse result id exists", response.getResultId() != null);
+    }
+
+    @Test
+    public void SearchShouldReturnAResultWithVariations() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", "key_dKjn8oS8czBw7Ebv", true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        BrowseRequest request = new BrowseRequest("Color", "Blue");
+        BrowseResponse response = constructor.browse(request, userInfo);
+        assertEquals("browse results exist", response.getResponse().getResults().size(), 30);
+        assertEquals("browse result [variations] exists", response.getResponse().getResults().get(0).getVariations().size(), 8);
+        assertEquals("browse result variation [facets] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getFacets().size(), 8);
+        assertEquals("browse result variation [value] exists", response.getResponse().getResults().get(0).getVariations().get(0).getValue(), "Coat Aspesi blue");
+        assertEquals("browse result variation [variation id] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getVariationId(), "M0E20000000ECTT");
+        assertEquals("browse result variation [url] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getUrl(), "https://demo.commercetools.com/en/aspesi-coat-I502997385098-blue.html");
+        assertEquals("browse results count as expected", (int) response.getResponse().getTotalNumberOfResults(), 562);
+        assertTrue("browse result id exists", response.getResultId() != null);
+    }
+
+    @Test
+    public void SearchShouldReturnAResultWithSortOptions() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", "key_dKjn8oS8czBw7Ebv", true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        BrowseRequest request = new BrowseRequest("Color", "Blue");
+        BrowseResponse response = constructor.browse(request, userInfo);
+        assertEquals("browse result [sort options] exists", response.getResponse().getSortOptions().size(), 1);
+        assertEquals("browse result sort option [display name] exists", response.getResponse().getSortOptions().get(0).getDisplayName(), "Relevance");
+        assertEquals("browse result sort option [sort by] exists", response.getResponse().getSortOptions().get(0).getSortBy(), "relevance");
+        assertEquals("browse result sort option [sort order] exists", response.getResponse().getSortOptions().get(0).getSortOrder(), "descending");
+        assertEquals("browse result sort option [status] exists", response.getResponse().getSortOptions().get(0).getStatus(), "selected");
+        assertEquals("browse results count as expected", (int) response.getResponse().getTotalNumberOfResults(), 562);
         assertTrue("browse result id exists", response.getResultId() != null);
     }
 

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -34,6 +34,37 @@ public class ConstructorIOSearchTest {
     }
 
     @Test
+    public void createSearchResponseShouldReturnAResultWithVariations() throws Exception {
+        String string = Utils.getTestResource("response.browse.color.blue.json");
+        SearchResponse response = ConstructorIO.createSearchResponse(string);
+        assertEquals("search facets exists", response.getResponse().getFacets().size(), 7);
+        assertEquals("search groups exists", response.getResponse().getGroups().size(), 1);
+        assertEquals("search results exists", response.getResponse().getResults().size(), 5);
+        assertEquals("search result [id] exists", response.getResponse().getResults().get(0).getData().getId(), "aspesi-coat-I502997385098-blue");
+        assertEquals("search result [variation id] exists", response.getResponse().getResults().get(0).getData().getVariationId(), "M0E20000000ECTT");
+        assertEquals("search result [variations] exists", response.getResponse().getResults().get(0).getVariations().size(), 8);
+        assertEquals("search result variation [facets] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getFacets().size(), 8);
+        assertEquals("search result variation [value] exists", response.getResponse().getResults().get(0).getVariations().get(0).getValue(), "Coat Aspesi blue");
+        assertEquals("search result variation [variation id] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getVariationId(), "M0E20000000ECTT");
+        assertEquals("search result variation [image] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getImageUrl(), "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081200_1_large.jpg");
+        assertEquals("total number of results", (int)response.getResponse().getTotalNumberOfResults(), 562);
+        assertTrue("search result id exists", response.getResultId() != null);
+    }
+
+    @Test
+    public void createSearchResponseShouldReturnAResultWithSortOptions() throws Exception {
+        String string = Utils.getTestResource("response.browse.color.blue.json");
+        SearchResponse response = ConstructorIO.createSearchResponse(string);
+        assertEquals("search result [sort options] exists", response.getResponse().getSortOptions().size(), 4);
+        assertEquals("search result sort option [display name] exists", response.getResponse().getSortOptions().get(0).getDisplayName(), "Relevance");
+        assertEquals("search result sort option [sort by] exists", response.getResponse().getSortOptions().get(0).getSortBy(), "relevance");
+        assertEquals("search result sort option [sort order] exists", response.getResponse().getSortOptions().get(0).getSortOrder(), "descending");
+        assertEquals("search result sort option [status] exists", response.getResponse().getSortOptions().get(0).getStatus(), "selected");
+        assertEquals("total number of results", (int)response.getResponse().getTotalNumberOfResults(), 562);
+        assertTrue("search result id exists", response.getResultId() != null);
+    }
+
+    @Test
     public void SearchShouldReturnAResult() throws Exception {
         ConstructorIO constructor = new ConstructorIO("", "key_K2hlXt5aVSwoI1Uw", true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
@@ -101,6 +132,37 @@ public class ConstructorIOSearchTest {
         SearchResponse response = constructor.search(request, userInfo);
         assertEquals("search results exist", response.getResponse().getResults().size(), 2);
         assertEquals("search results count as expected", (int)response.getResponse().getTotalNumberOfResults(), 2);
+        assertTrue("search result id exists", response.getResultId() != null);
+    }
+
+    @Test
+    public void SearchShouldReturnAResultWithVariations() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", "key_dKjn8oS8czBw7Ebv", true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        SearchRequest request = new SearchRequest("jacket");
+        SearchResponse response = constructor.search(request, userInfo);
+        assertEquals("search results exist", response.getResponse().getResults().size(), 30);
+        assertEquals("search result [variations] exists", response.getResponse().getResults().get(0).getVariations().size(), 13);
+        assertEquals("search result variation [facets] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getFacets().size(), 8);
+        assertEquals("search result variation [value] exists", response.getResponse().getResults().get(0).getVariations().get(0).getValue(), "Bully – Leather Jacket");
+        assertEquals("search result variation [variation id] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getVariationId(), "M0E20000000FBLO");
+        assertEquals("search result variation [url] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getUrl(), "https://demo.commercetools.com/en/bully-leather-jacket-251-grey.html");
+        assertEquals("search results count as expected", (int) response.getResponse().getTotalNumberOfResults(), 261);
+        assertTrue("search result id exists", response.getResultId() != null);
+    }
+
+    @Test
+    public void SearchShouldReturnAResultWithSortOptions() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", "key_dKjn8oS8czBw7Ebv", true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        SearchRequest request = new SearchRequest("jacket");
+        SearchResponse response = constructor.search(request, userInfo);
+        assertEquals("search result [sort options] exists", response.getResponse().getSortOptions().size(), 1);
+        assertEquals("search result sort option [display name] exists", response.getResponse().getSortOptions().get(0).getDisplayName(), "Relevance");
+        assertEquals("search result sort option [sort by] exists", response.getResponse().getSortOptions().get(0).getSortBy(), "relevance");
+        assertEquals("search result sort option [sort order] exists", response.getResponse().getSortOptions().get(0).getSortOrder(), "descending");
+        assertEquals("search result sort option [status] exists", response.getResponse().getSortOptions().get(0).getStatus(), "selected");
+        assertEquals("search results count as expected", (int) response.getResponse().getTotalNumberOfResults(), 261);
         assertTrue("search result id exists", response.getResultId() != null);
     }
 

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -35,32 +35,36 @@ public class ConstructorIOSearchTest {
 
     @Test
     public void createSearchResponseShouldReturnAResultWithVariations() throws Exception {
-        String string = Utils.getTestResource("response.browse.color.blue.json");
+        String string = Utils.getTestResource("response.search.shirt.json");
         SearchResponse response = ConstructorIO.createSearchResponse(string);
         assertEquals("search facets exists", response.getResponse().getFacets().size(), 7);
         assertEquals("search groups exists", response.getResponse().getGroups().size(), 1);
-        assertEquals("search results exists", response.getResponse().getResults().size(), 5);
-        assertEquals("search result [id] exists", response.getResponse().getResults().get(0).getData().getId(), "aspesi-coat-I502997385098-blue");
-        assertEquals("search result [variation id] exists", response.getResponse().getResults().get(0).getData().getVariationId(), "M0E20000000ECTT");
-        assertEquals("search result [variations] exists", response.getResponse().getResults().get(0).getVariations().size(), 8);
+        assertEquals("search results exists", response.getResponse().getResults().size(), 20);
+        assertEquals("search result [id] exists", response.getResponse().getResults().get(0).getData().getId(), "bully-leather-jacket-251-grey");
+        assertEquals("search result [variation id] exists", response.getResponse().getResults().get(0).getData().getVariationId(), "M0E20000000FBLO");
+        assertEquals("search result [variations] exists", response.getResponse().getResults().get(0).getVariations().size(), 13);
         assertEquals("search result variation [facets] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getFacets().size(), 8);
-        assertEquals("search result variation [value] exists", response.getResponse().getResults().get(0).getVariations().get(0).getValue(), "Coat Aspesi blue");
-        assertEquals("search result variation [variation id] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getVariationId(), "M0E20000000ECTT");
-        assertEquals("search result variation [image] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getImageUrl(), "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081200_1_large.jpg");
-        assertEquals("total number of results", (int)response.getResponse().getTotalNumberOfResults(), 562);
+        assertEquals("search result variation [value] exists", response.getResponse().getResults().get(0).getVariations().get(0).getValue(), "Bully – Leather Jacket");
+        assertEquals("search result variation [variation id] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getVariationId(), "M0E20000000FBLO");
+        assertEquals("search result variation [image url] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getImageUrl(), "https://demo.commercetools.com/en/bully-leather-jacket-251-grey.html");
+        assertEquals("search result variation [url] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getUrl(), "https://demo.commercetools.com/en/bully-leather-jacket-251-grey.html");
+        assertTrue("search result variation [metadata] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getMetadata() != null);
+        assertEquals("search result variation metadata [product type] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getMetadata().get("productType"), "Apparel");
+        assertEquals("search result variation metadata [price] exists", response.getResponse().getResults().get(0).getVariations().get(0).getData().getMetadata().get("price"), "411.25");
+        assertEquals("total number of results", (int)response.getResponse().getTotalNumberOfResults(), 261);
         assertTrue("search result id exists", response.getResultId() != null);
     }
 
     @Test
     public void createSearchResponseShouldReturnAResultWithSortOptions() throws Exception {
-        String string = Utils.getTestResource("response.browse.color.blue.json");
+        String string = Utils.getTestResource("response.search.shirt.json");
         SearchResponse response = ConstructorIO.createSearchResponse(string);
-        assertEquals("search result [sort options] exists", response.getResponse().getSortOptions().size(), 4);
+        assertEquals("search result [sort options] exists", response.getResponse().getSortOptions().size(), 1);
         assertEquals("search result sort option [display name] exists", response.getResponse().getSortOptions().get(0).getDisplayName(), "Relevance");
         assertEquals("search result sort option [sort by] exists", response.getResponse().getSortOptions().get(0).getSortBy(), "relevance");
         assertEquals("search result sort option [sort order] exists", response.getResponse().getSortOptions().get(0).getSortOrder(), "descending");
         assertEquals("search result sort option [status] exists", response.getResponse().getSortOptions().get(0).getStatus(), "selected");
-        assertEquals("total number of results", (int)response.getResponse().getTotalNumberOfResults(), 562);
+        assertEquals("total number of results", (int)response.getResponse().getTotalNumberOfResults(), 261);
         assertTrue("search result id exists", response.getResultId() != null);
     }
 

--- a/constructorio-client/src/test/resources/response.browse.color.blue.json
+++ b/constructorio-client/src/test/resources/response.browse.color.blue.json
@@ -1083,7 +1083,9 @@
           }],
           "url": "https://demo.commercetools.com/en/aspesi-coat-I502997385098-blue.html",
           "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081200_1_large.jpg",
-          "variation_id": "M0E20000000ECTT"
+          "variation_id": "M0E20000000ECTT",
+          "productType": "Outerwear",
+          "price": "536.25"
         },
         "value": "Coat Aspesi blue"
       }, {

--- a/constructorio-client/src/test/resources/response.browse.color.blue.json
+++ b/constructorio-client/src/test/resources/response.browse.color.blue.json
@@ -1082,6 +1082,7 @@
             "values": ["Business"]
           }],
           "url": "https://demo.commercetools.com/en/aspesi-coat-I502997385098-blue.html",
+          "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081200_1_large.jpg",
           "variation_id": "M0E20000000ECTT"
         },
         "value": "Coat Aspesi blue"
@@ -4172,7 +4173,30 @@
         "value": "Lace up shoes Tods blue"
       }]
     }],
-    "sort_options": [],
+    "sort_options": [{
+      "display_name": "Relevance",
+      "sort_by": "relevance",
+      "sort_order": "descending",
+      "status": "selected"
+    },
+    {
+      "display_name": "Lowest Price",
+      "sort_by": "salePrice",
+      "sort_order": "ascending",
+      "status": ""
+    },
+    {
+      "display_name": "Highest Price",
+      "sort_by": "salePrice",
+      "sort_order": "descending",
+      "status": ""
+    },
+    {
+      "display_name": "Percent Off",
+      "sort_by": "discountPercent",
+      "sort_order": "descending",
+      "status": ""
+    }],
     "total_num_results": 562
   },
   "result_id": "99dec817-4807-48fb-a00f-4b6e464f540e"

--- a/constructorio-client/src/test/resources/response.search.shirt.json
+++ b/constructorio-client/src/test/resources/response.search.shirt.json
@@ -1,0 +1,8466 @@
+{
+  "request": {
+    "feature_variants": {
+      "auto_generated_refined_query_rules": "default_rules",
+      "filter_items": null,
+      "manual_searchandizing": null,
+      "personalization": null,
+      "query_items": "query_items_ctr_and_l2r"
+    },
+    "features": {
+      "auto_generated_refined_query_rules": true,
+      "filter_items": true,
+      "manual_searchandizing": true,
+      "personalization": true,
+      "query_items": true
+    },
+    "fmt_options": {
+      "groups_max_depth": 1,
+      "groups_start": "current"
+    },
+    "num_results_per_page": 20,
+    "page": 1,
+    "searchandized_items": {},
+    "section": "Products",
+    "sort_by": "relevance",
+    "sort_order": "descending",
+    "term": "jacket"
+  },
+  "response": {
+    "facets": [{
+      "display_name": "Brand",
+      "name": "Brand",
+      "options": [{
+        "count": 28,
+        "data": {},
+        "display_name": "Bully",
+        "status": "",
+        "value": "Bully"
+      }, {
+        "count": 5,
+        "data": {},
+        "display_name": "Refrigue",
+        "status": "",
+        "value": "Refrigue"
+      }, {
+        "count": 40,
+        "data": {},
+        "display_name": "Savetheduck",
+        "status": "",
+        "value": "Savetheduck"
+      }, {
+        "count": 33,
+        "data": {},
+        "display_name": "Moncler",
+        "status": "",
+        "value": "Moncler"
+      }, {
+        "count": 26,
+        "data": {},
+        "display_name": "Peuterey",
+        "status": "",
+        "value": "Peuterey"
+      }, {
+        "count": 18,
+        "data": {},
+        "display_name": "Invicta",
+        "status": "",
+        "value": "Invicta"
+      }, {
+        "count": 15,
+        "data": {},
+        "display_name": "Pinko",
+        "status": "",
+        "value": "Pinko"
+      }, {
+        "count": 14,
+        "data": {},
+        "display_name": "Herno",
+        "status": "",
+        "value": "Herno"
+      }, {
+        "count": 10,
+        "data": {},
+        "display_name": "Michaelkors",
+        "status": "",
+        "value": "Michaelkors"
+      }, {
+        "count": 6,
+        "data": {},
+        "display_name": "Freedomday",
+        "status": "",
+        "value": "Freedomday"
+      }, {
+        "count": 6,
+        "data": {},
+        "display_name": "Blauer",
+        "status": "",
+        "value": "Blauer"
+      }, {
+        "count": 5,
+        "data": {},
+        "display_name": "Twinset",
+        "status": "",
+        "value": "Twinset"
+      }, {
+        "count": 5,
+        "data": {},
+        "display_name": "Gms 75",
+        "status": "",
+        "value": "Gms 75"
+      }, {
+        "count": 4,
+        "data": {},
+        "display_name": "Whoareyou",
+        "status": "",
+        "value": "Whoareyou"
+      }, {
+        "count": 4,
+        "data": {},
+        "display_name": "Duvetica",
+        "status": "",
+        "value": "Duvetica"
+      }, {
+        "count": 4,
+        "data": {},
+        "display_name": "Drows",
+        "status": "",
+        "value": "Drows"
+      }, {
+        "count": 3,
+        "data": {},
+        "display_name": "Luistrenker",
+        "status": "",
+        "value": "Luistrenker"
+      }, {
+        "count": 2,
+        "data": {},
+        "display_name": "Hogan",
+        "status": "",
+        "value": "Hogan"
+      }, {
+        "count": 2,
+        "data": {},
+        "display_name": "Elisabettafranchi",
+        "status": "",
+        "value": "Elisabettafranchi"
+      }, {
+        "count": 1,
+        "data": {},
+        "display_name": "Jucca",
+        "status": "",
+        "value": "Jucca"
+      }, {
+        "count": 1,
+        "data": {},
+        "display_name": "Valentino",
+        "status": "",
+        "value": "Valentino"
+      }, {
+        "count": 1,
+        "data": {},
+        "display_name": "Moschinocheap",
+        "status": "",
+        "value": "Moschinocheap"
+      }, {
+        "count": 1,
+        "data": {},
+        "display_name": "Cycle",
+        "status": "",
+        "value": "Cycle"
+      }, {
+        "count": 6,
+        "data": {},
+        "display_name": "Aspesi",
+        "status": "",
+        "value": "Aspesi"
+      }, {
+        "count": 7,
+        "data": {},
+        "display_name": "Danielealessandrini",
+        "status": "",
+        "value": "Danielealessandrini"
+      }, {
+        "count": 4,
+        "data": {},
+        "display_name": "Stoneisland",
+        "status": "",
+        "value": "Stoneisland"
+      }, {
+        "count": 3,
+        "data": {},
+        "display_name": "Harriswharf",
+        "status": "",
+        "value": "Harriswharf"
+      }, {
+        "count": 2,
+        "data": {},
+        "display_name": "Oakwood",
+        "status": "",
+        "value": "Oakwood"
+      }, {
+        "count": 2,
+        "data": {},
+        "display_name": "Moorer",
+        "status": "",
+        "value": "Moorer"
+      }, {
+        "count": 2,
+        "data": {},
+        "display_name": "Aereonautica",
+        "status": "",
+        "value": "Aereonautica"
+      }, {
+        "count": 1,
+        "data": {},
+        "display_name": "Brunello",
+        "status": "",
+        "value": "Brunello"
+      }],
+      "type": "multiple"
+    }, {
+      "display_name": "Color",
+      "name": "Color",
+      "options": [{
+        "count": 38,
+        "data": {},
+        "display_name": "Grey",
+        "status": "",
+        "value": "Grey"
+      }, {
+        "count": 20,
+        "data": {},
+        "display_name": "Green",
+        "status": "",
+        "value": "Green"
+      }, {
+        "count": 17,
+        "data": {},
+        "display_name": "Brown",
+        "status": "",
+        "value": "Brown"
+      }, {
+        "count": 68,
+        "data": {},
+        "display_name": "Blue",
+        "status": "",
+        "value": "Blue"
+      }, {
+        "count": 48,
+        "data": {},
+        "display_name": "Black",
+        "status": "",
+        "value": "Black"
+      }, {
+        "count": 28,
+        "data": {},
+        "display_name": "Beige",
+        "status": "",
+        "value": "Beige"
+      }, {
+        "count": 8,
+        "data": {},
+        "display_name": "Red",
+        "status": "",
+        "value": "Red"
+      }, {
+        "count": 6,
+        "data": {},
+        "display_name": "Pink",
+        "status": "",
+        "value": "Pink"
+      }, {
+        "count": 4,
+        "data": {},
+        "display_name": "White",
+        "status": "",
+        "value": "White"
+      }, {
+        "count": 3,
+        "data": {},
+        "display_name": "Yellow",
+        "status": "",
+        "value": "Yellow"
+      }, {
+        "count": 1,
+        "data": {},
+        "display_name": "Turquoise",
+        "status": "",
+        "value": "Turquoise"
+      }, {
+        "count": 1,
+        "data": {},
+        "display_name": "Orange",
+        "status": "",
+        "value": "Orange"
+      }, {
+        "count": 1,
+        "data": {},
+        "display_name": "Gold",
+        "status": "",
+        "value": "Gold"
+      }, {
+        "count": 10,
+        "data": {},
+        "display_name": "Oliv",
+        "status": "",
+        "value": "Oliv"
+      }, {
+        "count": 5,
+        "data": {},
+        "display_name": "Multicolored",
+        "status": "",
+        "value": "Multicolored"
+      }, {
+        "count": 1,
+        "data": {},
+        "display_name": "Silver",
+        "status": "",
+        "value": "Silver"
+      }],
+      "type": "multiple"
+    }, {
+      "display_name": "Gender",
+      "name": "Gender",
+      "options": [{
+        "count": 161,
+        "data": {},
+        "display_name": "Women",
+        "status": "",
+        "value": "Women"
+      }, {
+        "count": 100,
+        "data": {},
+        "display_name": "Men",
+        "status": "",
+        "value": "Men"
+      }],
+      "type": "multiple"
+    }, {
+      "display_name": "Made In Italy",
+      "name": "Made In Italy",
+      "options": [{
+        "count": 200,
+        "data": {},
+        "display_name": "No",
+        "status": "",
+        "value": "No"
+      }, {
+        "count": 31,
+        "data": {},
+        "display_name": "Yes",
+        "status": "",
+        "value": "Yes"
+      }],
+      "type": "multiple"
+    }, {
+      "display_name": "Price",
+      "max": 2181.25,
+      "min": 111.25,
+      "name": "Price",
+      "status": {},
+      "type": "range"
+    }, {
+      "display_name": "Size",
+      "name": "Common Size",
+      "options": [{
+        "count": 173,
+        "data": {},
+        "display_name": "XXS",
+        "status": "",
+        "value": "XXS"
+      }, {
+        "count": 261,
+        "data": {},
+        "display_name": "L",
+        "status": "",
+        "value": "L"
+      }, {
+        "count": 261,
+        "data": {},
+        "display_name": "M",
+        "status": "",
+        "value": "M"
+      }, {
+        "count": 261,
+        "data": {},
+        "display_name": "S",
+        "status": "",
+        "value": "S"
+      }, {
+        "count": 261,
+        "data": {},
+        "display_name": "XL",
+        "status": "",
+        "value": "XL"
+      }, {
+        "count": 261,
+        "data": {},
+        "display_name": "XS",
+        "status": "",
+        "value": "XS"
+      }, {
+        "count": 261,
+        "data": {},
+        "display_name": "XXL",
+        "status": "",
+        "value": "XXL"
+      }, {
+        "count": 261,
+        "data": {},
+        "display_name": "XXXL",
+        "status": "",
+        "value": "XXXL"
+      }],
+      "type": "multiple"
+    }, {
+      "display_name": "Style",
+      "name": "Style",
+      "options": [{
+        "count": 226,
+        "data": {},
+        "display_name": "Sporty",
+        "status": "",
+        "value": "Sporty"
+      }, {
+        "count": 16,
+        "data": {},
+        "display_name": "Business",
+        "status": "",
+        "value": "Business"
+      }],
+      "type": "multiple"
+    }],
+    "features": [{
+      "display_name": "Affinity Engine",
+      "enabled": true,
+      "feature_name": "auto_generated_refined_query_rules",
+      "variant": {
+        "display_name": "Default weights",
+        "name": "default_rules"
+      }
+    }, {
+      "display_name": "Filter-item boosts",
+      "enabled": true,
+      "feature_name": "filter_items",
+      "variant": null
+    }, {
+      "display_name": "Searchandizing",
+      "enabled": true,
+      "feature_name": "manual_searchandizing",
+      "variant": null
+    }, {
+      "display_name": "Personalization",
+      "enabled": true,
+      "feature_name": "personalization",
+      "variant": null
+    }, {
+      "display_name": "Learn To Rank",
+      "enabled": true,
+      "feature_name": "query_items",
+      "variant": {
+        "display_name": "CTR & LTR",
+        "name": "query_items_ctr_and_l2r"
+      }
+    }],
+    "groups": [{
+      "children": [{
+        "children": [],
+        "count": 163,
+        "display_name": "Women",
+        "group_id": "women",
+        "parents": [{
+          "display_name": "All",
+          "group_id": "all"
+        }]
+      }, {
+        "children": [],
+        "count": 152,
+        "display_name": "Sale",
+        "group_id": "sale",
+        "parents": [{
+          "display_name": "All",
+          "group_id": "all"
+        }]
+      }, {
+        "children": [],
+        "count": 5,
+        "display_name": "New",
+        "group_id": "new",
+        "parents": [{
+          "display_name": "All",
+          "group_id": "all"
+        }]
+      }, {
+        "children": [],
+        "count": 98,
+        "display_name": "Men",
+        "group_id": "men",
+        "parents": [{
+          "display_name": "All",
+          "group_id": "all"
+        }]
+      }],
+      "count": 261,
+      "display_name": "All",
+      "group_id": "all",
+      "parents": []
+    }],
+    "results": [{
+      "data": {
+        "description": "Thanks to their perfect tailoring, leather jackets by Bully are a favorite choice, not only for fashion insiders. Softest leather and modern manufacturing techniques create investment pieces that will add status to any look for a long time!",
+        "facets": [{
+          "name": "Brand",
+          "values": ["Bully"]
+        }, {
+          "name": "Color",
+          "values": ["Grey"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [411.25]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "bully-leather-jacket-251-grey",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/085956_1_medium.jpg",
+        "price": 411.25,
+        "url": "https://demo.commercetools.com/en/bully-leather-jacket-251-grey.html",
+        "variation_id": "M0E20000000FBLO",
+        "weighted_keywords": {
+          "jacket": 5.7
+        }
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Bully \u2013 Leather Jacket",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/bully-leather-jacket-251-grey.html",
+          "image_url": "https://demo.commercetools.com/en/bully-leather-jacket-251-grey.html",
+          "variation_id": "M0E20000000FBLO",
+          "price": "411.25",
+          "productType": "Apparel"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLP"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLQ"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLR"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLS"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLT"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLU"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLV"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLW"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLX"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLY"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBLZ"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [411.25]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBM0"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }]
+    }, {
+      "data": {
+        "description": "Thanks to their perfect tailoring, leather jackets by Bully are a favorite choice, not only for fashion insiders. Softest leather and modern manufacturing techniques create investment pieces that will add status to any look for a long time!",
+        "facets": [{
+          "name": "Brand",
+          "values": ["Bully"]
+        }, {
+          "name": "Color",
+          "values": ["Green"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [448.75]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "bully-leather-jacket-8064-green",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/085953_1_medium.jpg",
+        "price": 448.75,
+        "url": "https://demo.commercetools.com/en/bully-leather-jacket-8064-green.html",
+        "variation_id": "M0E20000000FBKL",
+        "weighted_keywords": {
+          "jacket": 5.7
+        }
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Bully \u2013 Leather Jacket",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/bully-leather-jacket-8064-green.html",
+          "variation_id": "M0E20000000FBKL"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKM"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKN"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKO"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKP"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKQ"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKR"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKS"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKT"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKU"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKV"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKW"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBKX"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Bully"]
+        }, {
+          "name": "Color",
+          "values": ["Brown"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [372.5]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "bully-leatherjacket-251-brown",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/079433_1_large.jpg",
+        "price": 372.5,
+        "url": "https://demo.commercetools.com/en/bully-leatherjacket-251-brown.html",
+        "variation_id": "M0E20000000DZH9"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Leather jacket Bully brown",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/bully-leatherjacket-251-brown.html",
+          "variation_id": "M0E20000000DZH9"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHA"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHB"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHC"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHD"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHE"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHF"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHG"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHH"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHI"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHJ"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHK"
+        },
+        "value": "Leather jacket Bully brown"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Brown"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [372.5]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZHL"
+        },
+        "value": "Leather jacket Bully brown"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Bully"]
+        }, {
+          "name": "Color",
+          "values": ["Grey"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [423.75]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Clothing",
+          "group_id": "sale|women|clothing",
+          "path": "/all/sale/sale|women",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }, {
+            "display_name": "Women",
+            "id": "sale|women"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "bully-leather-jacket-1719-grey",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/079439_1_large.jpg",
+        "price": 423.75,
+        "url": "https://demo.commercetools.com/en/bully-leather-jacket-1719-grey.html",
+        "variation_id": "M0E20000000DZJK"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Leather jacket Bully grey",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/bully-leather-jacket-1719-grey.html",
+          "variation_id": "M0E20000000DZJK"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJL"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJM"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJN"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJO"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJP"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJQ"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJR"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJS"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJT"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJU"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJV"
+        },
+        "value": "Leather jacket Bully grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [423.75]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DZJW"
+        },
+        "value": "Leather jacket Bully grey"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Refrigue"]
+        }, {
+          "name": "Color",
+          "values": ["Grey"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [181.25]
+        }, {
+          "name": "Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Clothing",
+          "group_id": "sale|women|clothing",
+          "path": "/all/sale/sale|women",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }, {
+            "display_name": "Women",
+            "id": "sale|women"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "refrigue-jacket-nedda-grey",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081450_1_large.jpg",
+        "price": 181.25,
+        "url": "https://demo.commercetools.com/en/refrigue-jacket-nedda-grey.html",
+        "variation_id": "M0E20000000EEZZ"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Jacket \u201cNedda\u201c Refrigue grey",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Refrigue"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [181.25]
+          }, {
+            "name": "Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/refrigue-jacket-nedda-grey.html",
+          "variation_id": "M0E20000000EEZZ"
+        },
+        "value": "Jacket \u201cNedda\u201c Refrigue grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Refrigue"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [181.25]
+          }, {
+            "name": "Size",
+            "values": ["XS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EF00"
+        },
+        "value": "Jacket \u201cNedda\u201c Refrigue grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Refrigue"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [181.25]
+          }, {
+            "name": "Size",
+            "values": ["S"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EF01"
+        },
+        "value": "Jacket \u201cNedda\u201c Refrigue grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Refrigue"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [181.25]
+          }, {
+            "name": "Size",
+            "values": ["M"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EF02"
+        },
+        "value": "Jacket \u201cNedda\u201c Refrigue grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Refrigue"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [181.25]
+          }, {
+            "name": "Size",
+            "values": ["L"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EF03"
+        },
+        "value": "Jacket \u201cNedda\u201c Refrigue grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Refrigue"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [181.25]
+          }, {
+            "name": "Size",
+            "values": ["XL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EF04"
+        },
+        "value": "Jacket \u201cNedda\u201c Refrigue grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Refrigue"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [181.25]
+          }, {
+            "name": "Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EF05"
+        },
+        "value": "Jacket \u201cNedda\u201c Refrigue grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Refrigue"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [181.25]
+          }, {
+            "name": "Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EF06"
+        },
+        "value": "Jacket \u201cNedda\u201c Refrigue grey"
+      }]
+    }, {
+      "data": {
+        "description": "Thanks to their perfect tailoring, leather jackets by Bully are a favorite choice, not only for fashion insiders. Softest leather and modern manufacturing techniques create investment pieces that will add status to any look for a long time!",
+        "facets": [{
+          "name": "Brand",
+          "values": ["Bully"]
+        }, {
+          "name": "Color",
+          "values": ["Grey"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [448.75]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "bully-leather-jacket-8064-grey",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/085951_1_medium.jpg",
+        "price": 448.75,
+        "url": "https://demo.commercetools.com/en/bully-leather-jacket-8064-grey.html",
+        "variation_id": "M0E20000000FBJE"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Bully \u2013 Leather Jacket",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/bully-leather-jacket-8064-grey.html",
+          "variation_id": "M0E20000000FBJE"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJF"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJG"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJH"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJI"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJJ"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJK"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJL"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJM"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJN"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJO"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJP"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Bully"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000FBJQ"
+        },
+        "value": "Bully \u2013 Leather Jacket"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Luistrenker"]
+        }, {
+          "name": "Color",
+          "values": ["Beige"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["Yes"]
+        }, {
+          "name": "Price",
+          "values": [436.25]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Women",
+          "group_id": "sale|women",
+          "path": "/all/sale",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "luistrenker-jacket-K245511299-cream",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/079933_1_medium.jpg",
+        "price": 436.25,
+        "url": "https://demo.commercetools.com/en/luistrenker-jacket-K245511299-cream.html",
+        "variation_id": "M0E20000000E2ZJ"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Jacket \u201cRivka\u201c Luis Trenker cream",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/luistrenker-jacket-K245511299-cream.html",
+          "variation_id": "M0E20000000E2ZJ"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZK"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZL"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZM"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZN"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZO"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZP"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZQ"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZR"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZS"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZT"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZU"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Luistrenker"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [436.25]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E2ZV"
+        },
+        "value": "Jacket \u201cRivka\u201c Luis Trenker cream"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Moncler"]
+        }, {
+          "name": "Color",
+          "values": ["Blue"]
+        }, {
+          "name": "Common Size",
+          "values": ["XS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [562.5]
+        }, {
+          "name": "Size",
+          "values": ["0"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "moncler-downjacket-lans-778-blue",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/078863_1_large.jpg",
+        "price": 562.5,
+        "url": "https://demo.commercetools.com/en/moncler-downjacket-lans-778-blue.html",
+        "variation_id": "M0E20000000DU5Z"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Down jacket \u201dLans\u201d Moncler blue",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [562.5]
+          }, {
+            "name": "Size",
+            "values": ["0"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/moncler-downjacket-lans-778-blue.html",
+          "variation_id": "M0E20000000DU5Z"
+        },
+        "value": "Down jacket \u201dLans\u201d Moncler blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [562.5]
+          }, {
+            "name": "Size",
+            "values": ["1"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU60"
+        },
+        "value": "Down jacket \u201dLans\u201d Moncler blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [562.5]
+          }, {
+            "name": "Size",
+            "values": ["2"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU61"
+        },
+        "value": "Down jacket \u201dLans\u201d Moncler blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [562.5]
+          }, {
+            "name": "Size",
+            "values": ["3"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU62"
+        },
+        "value": "Down jacket \u201dLans\u201d Moncler blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [562.5]
+          }, {
+            "name": "Size",
+            "values": ["4"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU63"
+        },
+        "value": "Down jacket \u201dLans\u201d Moncler blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [562.5]
+          }, {
+            "name": "Size",
+            "values": ["5"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU64"
+        },
+        "value": "Down jacket \u201dLans\u201d Moncler blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [562.5]
+          }, {
+            "name": "Size",
+            "values": ["6"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU65"
+        },
+        "value": "Down jacket \u201dLans\u201d Moncler blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [562.5]
+          }, {
+            "name": "Size",
+            "values": ["7"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU66"
+        },
+        "value": "Down jacket \u201dLans\u201d Moncler blue"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Duvetica"]
+        }, {
+          "name": "Color",
+          "values": ["Beige"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [431.25]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Women",
+          "group_id": "sale|women",
+          "path": "/all/sale",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "duvetica-downjacket-scea-CEADUEERRE912-cream",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/078943_1_medium.jpg",
+        "price": 431.25,
+        "url": "https://demo.commercetools.com/en/duvetica-downjacket-scea-CEADUEERRE912-cream.html",
+        "variation_id": "M0E20000000DV69"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/duvetica-downjacket-scea-CEADUEERRE912-cream.html",
+          "variation_id": "M0E20000000DV69"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6A"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6B"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6C"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6D"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6E"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6F"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6G"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6H"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6I"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6J"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6K"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Duvetica"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [431.25]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DV6L"
+        },
+        "value": "Down jacket Doubleface \u201cScea\u201c Duvetica cream"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Pinko"]
+        }, {
+          "name": "Color",
+          "values": ["Black"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [343.75]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Women",
+          "group_id": "sale|women",
+          "path": "/all/sale",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "pinko-jacket-1G110KY1ACZ99-black",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/072614_1_medium.jpg",
+        "price": 343.75,
+        "url": "https://demo.commercetools.com/en/pinko-jacket-1G110KY1ACZ99-black.html",
+        "variation_id": "M0E20000000DJW9"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Jacket Pinko black",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/pinko-jacket-1G110KY1ACZ99-black.html",
+          "variation_id": "M0E20000000DJW9"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWA"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWB"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWC"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWD"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWE"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWF"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWG"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWH"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWI"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWJ"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWK"
+        },
+        "value": "Jacket Pinko black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Pinko"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [343.75]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJWL"
+        },
+        "value": "Jacket Pinko black"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Michaelkors"]
+        }, {
+          "name": "Color",
+          "values": ["Orange"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [243.75]
+        }, {
+          "name": "Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "michaelkors-jacket-mh42h45gv2-orange",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/072774_1_medium.jpg",
+        "price": 243.75,
+        "url": "https://demo.commercetools.com/en/michaelkors-jacket-mh42h45gv2-orange.html",
+        "variation_id": "M0E20000000DLWF"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Jacket Michael Kors orange",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Michaelkors"]
+          }, {
+            "name": "Color",
+            "values": ["Orange"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/michaelkors-jacket-mh42h45gv2-orange.html",
+          "variation_id": "M0E20000000DLWF"
+        },
+        "value": "Jacket Michael Kors orange"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Michaelkors"]
+          }, {
+            "name": "Color",
+            "values": ["Orange"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["XS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DLWG"
+        },
+        "value": "Jacket Michael Kors orange"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Michaelkors"]
+          }, {
+            "name": "Color",
+            "values": ["Orange"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["S"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DLWH"
+        },
+        "value": "Jacket Michael Kors orange"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Michaelkors"]
+          }, {
+            "name": "Color",
+            "values": ["Orange"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["M"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DLWI"
+        },
+        "value": "Jacket Michael Kors orange"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Michaelkors"]
+          }, {
+            "name": "Color",
+            "values": ["Orange"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["L"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DLWJ"
+        },
+        "value": "Jacket Michael Kors orange"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Michaelkors"]
+          }, {
+            "name": "Color",
+            "values": ["Orange"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["XL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DLWK"
+        },
+        "value": "Jacket Michael Kors orange"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Michaelkors"]
+          }, {
+            "name": "Color",
+            "values": ["Orange"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DLWL"
+        },
+        "value": "Jacket Michael Kors orange"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Michaelkors"]
+          }, {
+            "name": "Color",
+            "values": ["Orange"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DLWM"
+        },
+        "value": "Jacket Michael Kors orange"
+      }]
+    }, {
+      "data": {
+        "description": "The down jacket by Herno completes our outfits with its quilted, shiny optic. The ultralight material makes it foldable and our favorite choice for the winter.",
+        "facets": [{
+          "name": "Brand",
+          "values": ["Herno"]
+        }, {
+          "name": "Color",
+          "values": ["Black"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Price",
+          "values": [556.25]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "herno-jacket-pi0043d12017-black",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/084999_1_medium.jpg",
+        "price": 556.25,
+        "url": "https://demo.commercetools.com/en/herno-jacket-pi0043d12017-black.html",
+        "variation_id": "M0E20000000F2W8"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Herno \u2013 Down Jacket",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/herno-jacket-pi0043d12017-black.html",
+          "variation_id": "M0E20000000F2W8"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2W9"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WA"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WB"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WC"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WD"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WE"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WF"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WG"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WH"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WI"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WJ"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Price",
+            "values": [556.25]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000F2WK"
+        },
+        "value": "Herno \u2013 Down Jacket"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Invicta"]
+        }, {
+          "name": "Color",
+          "values": ["Beige"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [198.75]
+        }, {
+          "name": "Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Women",
+          "group_id": "sale|women",
+          "path": "/all/sale",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "invicta-jacket-4436100885-cream",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/079992_1_medium.jpg",
+        "price": 198.75,
+        "url": "https://demo.commercetools.com/en/invicta-jacket-4436100885-cream.html",
+        "variation_id": "M0E20000000E3PF"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Jacket Invicta cream",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Invicta"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [198.75]
+          }, {
+            "name": "Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/invicta-jacket-4436100885-cream.html",
+          "variation_id": "M0E20000000E3PF"
+        },
+        "value": "Jacket Invicta cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Invicta"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [198.75]
+          }, {
+            "name": "Size",
+            "values": ["XS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E3PG"
+        },
+        "value": "Jacket Invicta cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Invicta"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [198.75]
+          }, {
+            "name": "Size",
+            "values": ["S"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E3PH"
+        },
+        "value": "Jacket Invicta cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Invicta"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [198.75]
+          }, {
+            "name": "Size",
+            "values": ["M"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E3PI"
+        },
+        "value": "Jacket Invicta cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Invicta"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [198.75]
+          }, {
+            "name": "Size",
+            "values": ["L"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E3PJ"
+        },
+        "value": "Jacket Invicta cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Invicta"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [198.75]
+          }, {
+            "name": "Size",
+            "values": ["XL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E3PK"
+        },
+        "value": "Jacket Invicta cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Invicta"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [198.75]
+          }, {
+            "name": "Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E3PL"
+        },
+        "value": "Jacket Invicta cream"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Invicta"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [198.75]
+          }, {
+            "name": "Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E3PM"
+        },
+        "value": "Jacket Invicta cream"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Freedomday"]
+        }, {
+          "name": "Color",
+          "values": ["Black"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [123.75]
+        }, {
+          "name": "Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Women",
+          "group_id": "sale|women",
+          "path": "/all/sale",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "freedomday-jacket-efw004-black",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081641_1_medium.jpg",
+        "price": 123.75,
+        "url": "https://demo.commercetools.com/en/freedomday-jacket-efw004-black.html",
+        "variation_id": "M0E20000000EGN9"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Jacket Freedomday black",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [123.75]
+          }, {
+            "name": "Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/freedomday-jacket-efw004-black.html",
+          "variation_id": "M0E20000000EGN9"
+        },
+        "value": "Jacket Freedomday black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [123.75]
+          }, {
+            "name": "Size",
+            "values": ["XS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGNA"
+        },
+        "value": "Jacket Freedomday black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [123.75]
+          }, {
+            "name": "Size",
+            "values": ["S"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGNB"
+        },
+        "value": "Jacket Freedomday black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [123.75]
+          }, {
+            "name": "Size",
+            "values": ["M"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGNC"
+        },
+        "value": "Jacket Freedomday black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [123.75]
+          }, {
+            "name": "Size",
+            "values": ["L"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGND"
+        },
+        "value": "Jacket Freedomday black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [123.75]
+          }, {
+            "name": "Size",
+            "values": ["XL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGNE"
+        },
+        "value": "Jacket Freedomday black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [123.75]
+          }, {
+            "name": "Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGNF"
+        },
+        "value": "Jacket Freedomday black"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Black"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [123.75]
+          }, {
+            "name": "Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGNG"
+        },
+        "value": "Jacket Freedomday black"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Herno"]
+        }, {
+          "name": "Color",
+          "values": ["Green"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [531.25]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "herno-downjacket-PI0265D120177001-green",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/072549_1_large.jpg",
+        "price": 531.25,
+        "url": "https://demo.commercetools.com/en/herno-downjacket-PI0265D120177001-green.html",
+        "variation_id": "M0E20000000DJ6F"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Down jacket Doubleface Herno green",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/herno-downjacket-PI0265D120177001-green.html",
+          "variation_id": "M0E20000000DJ6F"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6G"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6H"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6I"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6J"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6K"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6L"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6M"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6N"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6O"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6P"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6Q"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Herno"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [531.25]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DJ6R"
+        },
+        "value": "Down jacket Doubleface Herno green"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Savetheduck"]
+        }, {
+          "name": "Color",
+          "values": ["Green"]
+        }, {
+          "name": "Common Size",
+          "values": ["XS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [243.75]
+        }, {
+          "name": "Size",
+          "values": ["0"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Women",
+          "group_id": "sale|women",
+          "path": "/all/sale",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "save-the-duck-jacket-3355foto-green",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/078676_1_medium.jpg",
+        "price": 243.75,
+        "url": "https://demo.commercetools.com/en/save-the-duck-jacket-3355foto-green.html",
+        "variation_id": "M0E20000000DS8W"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Jacket Doubleface Save the Duck green",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Savetheduck"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["0"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/save-the-duck-jacket-3355foto-green.html",
+          "variation_id": "M0E20000000DS8W"
+        },
+        "value": "Jacket Doubleface Save the Duck green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Savetheduck"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["1"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DS8X"
+        },
+        "value": "Jacket Doubleface Save the Duck green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Savetheduck"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["2"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DS8Y"
+        },
+        "value": "Jacket Doubleface Save the Duck green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Savetheduck"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["3"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DS8Z"
+        },
+        "value": "Jacket Doubleface Save the Duck green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Savetheduck"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["4"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DS90"
+        },
+        "value": "Jacket Doubleface Save the Duck green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Savetheduck"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["5"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DS91"
+        },
+        "value": "Jacket Doubleface Save the Duck green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Savetheduck"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["6"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DS92"
+        },
+        "value": "Jacket Doubleface Save the Duck green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Savetheduck"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [243.75]
+          }, {
+            "name": "Size",
+            "values": ["7"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DS93"
+        },
+        "value": "Jacket Doubleface Save the Duck green"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Moncler"]
+        }, {
+          "name": "Color",
+          "values": ["Grey"]
+        }, {
+          "name": "Common Size",
+          "values": ["XS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [781.25]
+        }, {
+          "name": "Size",
+          "values": ["0"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "moncler-jacket-amy-grey",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/078865_1_large.jpg",
+        "price": 781.25,
+        "url": "https://demo.commercetools.com/en/moncler-jacket-amy-grey.html",
+        "variation_id": "M0E20000000DU6J"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Down jacket \u201dAmey\u201d Moncler grey",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [781.25]
+          }, {
+            "name": "Size",
+            "values": ["0"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/moncler-jacket-amy-grey.html",
+          "variation_id": "M0E20000000DU6J"
+        },
+        "value": "Down jacket \u201dAmey\u201d Moncler grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [781.25]
+          }, {
+            "name": "Size",
+            "values": ["1"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU6K"
+        },
+        "value": "Down jacket \u201dAmey\u201d Moncler grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [781.25]
+          }, {
+            "name": "Size",
+            "values": ["2"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU6L"
+        },
+        "value": "Down jacket \u201dAmey\u201d Moncler grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [781.25]
+          }, {
+            "name": "Size",
+            "values": ["3"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU6M"
+        },
+        "value": "Down jacket \u201dAmey\u201d Moncler grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [781.25]
+          }, {
+            "name": "Size",
+            "values": ["4"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU6N"
+        },
+        "value": "Down jacket \u201dAmey\u201d Moncler grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [781.25]
+          }, {
+            "name": "Size",
+            "values": ["5"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU6O"
+        },
+        "value": "Down jacket \u201dAmey\u201d Moncler grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [781.25]
+          }, {
+            "name": "Size",
+            "values": ["6"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU6P"
+        },
+        "value": "Down jacket \u201dAmey\u201d Moncler grey"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Moncler"]
+          }, {
+            "name": "Color",
+            "values": ["Grey"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [781.25]
+          }, {
+            "name": "Size",
+            "values": ["7"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DU6Q"
+        },
+        "value": "Down jacket \u201dAmey\u201d Moncler grey"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Freedomday"]
+        }, {
+          "name": "Color",
+          "values": ["Beige"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [173.75]
+        }, {
+          "name": "Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Style",
+          "values": ["Sporty"]
+        }],
+        "groups": [{
+          "display_name": "Women",
+          "group_id": "sale|women",
+          "path": "/all/sale",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "freedomday-jacket-efw007-beige",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/081639_1_medium.jpg",
+        "price": 173.75,
+        "url": "https://demo.commercetools.com/en/freedomday-jacket-efw007-beige.html",
+        "variation_id": "M0E20000000EGMT"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Jacket Freedomday beige",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [173.75]
+          }, {
+            "name": "Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/freedomday-jacket-efw007-beige.html",
+          "variation_id": "M0E20000000EGMT"
+        },
+        "value": "Jacket Freedomday beige"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [173.75]
+          }, {
+            "name": "Size",
+            "values": ["XS"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGMU"
+        },
+        "value": "Jacket Freedomday beige"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [173.75]
+          }, {
+            "name": "Size",
+            "values": ["S"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGMV"
+        },
+        "value": "Jacket Freedomday beige"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [173.75]
+          }, {
+            "name": "Size",
+            "values": ["M"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGMW"
+        },
+        "value": "Jacket Freedomday beige"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [173.75]
+          }, {
+            "name": "Size",
+            "values": ["L"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGMX"
+        },
+        "value": "Jacket Freedomday beige"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [173.75]
+          }, {
+            "name": "Size",
+            "values": ["XL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGMY"
+        },
+        "value": "Jacket Freedomday beige"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [173.75]
+          }, {
+            "name": "Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGMZ"
+        },
+        "value": "Jacket Freedomday beige"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Freedomday"]
+          }, {
+            "name": "Color",
+            "values": ["Beige"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [173.75]
+          }, {
+            "name": "Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Style",
+            "values": ["Sporty"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000EGN0"
+        },
+        "value": "Jacket Freedomday beige"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Whoareyou"]
+        }, {
+          "name": "Color",
+          "values": ["Green"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["Yes"]
+        }, {
+          "name": "Price",
+          "values": [448.75]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Business"]
+        }],
+        "groups": [{
+          "display_name": "Women",
+          "group_id": "sale|women",
+          "path": "/all/sale",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Sale",
+            "id": "sale"
+          }]
+        }, {
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "ki6-whoareyou-leatherjacket-CP06558-green",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/079644_1_medium.jpg",
+        "price": 448.75,
+        "url": "https://demo.commercetools.com/en/ki6-whoareyou-leatherjacket-CP06558-green.html",
+        "variation_id": "M0E20000000E1LD"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Leather jacket Ki 6? Who are you? green",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/ki6-whoareyou-leatherjacket-CP06558-green.html",
+          "variation_id": "M0E20000000E1LD"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LE"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LF"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LG"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LH"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LI"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LJ"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LK"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LL"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LM"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LN"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LO"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Whoareyou"]
+          }, {
+            "name": "Color",
+            "values": ["Green"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["Yes"]
+          }, {
+            "name": "Price",
+            "values": [448.75]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000E1LP"
+        },
+        "value": "Leather jacket Ki 6? Who are you? green"
+      }]
+    }, {
+      "data": {
+        "facets": [{
+          "name": "Brand",
+          "values": ["Hogan"]
+        }, {
+          "name": "Color",
+          "values": ["Blue"]
+        }, {
+          "name": "Common Size",
+          "values": ["XXS"]
+        }, {
+          "name": "Gender",
+          "values": ["Women"]
+        }, {
+          "name": "Made In Italy",
+          "values": ["No"]
+        }, {
+          "name": "Price",
+          "values": [497.5]
+        }, {
+          "name": "Size",
+          "values": ["34"]
+        }, {
+          "name": "Style",
+          "values": ["Business"]
+        }],
+        "groups": [{
+          "display_name": "Jackets",
+          "group_id": "women|clothing|jackets",
+          "path": "/all/women/women|clothing",
+          "path_list": [{
+            "display_name": "All",
+            "id": "all"
+          }, {
+            "display_name": "Women",
+            "id": "women"
+          }, {
+            "display_name": "Clothing",
+            "id": "women|clothing"
+          }]
+        }],
+        "id": "hogan-jacket-kjw12308450-blue",
+        "image_url": "https://s3-eu-west-1.amazonaws.com/commercetools-maximilian/products/079076_1_large.jpg",
+        "price": 497.5,
+        "url": "https://demo.commercetools.com/en/hogan-jacket-kjw12308450-blue.html",
+        "variation_id": "M0E20000000DWK2"
+      },
+      "is_slotted": false,
+      "matched_terms": ["jacket"],
+      "value": "Jacket Hogan dark blue",
+      "variations": [{
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["34"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/hogan-jacket-kjw12308450-blue.html",
+          "variation_id": "M0E20000000DWK2"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["36"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWK3"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["38"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWK4"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XS"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["40"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWK5"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["S"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["42"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWK6"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["M"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["44"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWK7"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["L"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["46"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWK8"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["48"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWK9"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["50"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWKA"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["52"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWKB"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["54"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWKC"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["56"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWKD"
+        },
+        "value": "Jacket Hogan dark blue"
+      }, {
+        "data": {
+          "facets": [{
+            "name": "Brand",
+            "values": ["Hogan"]
+          }, {
+            "name": "Color",
+            "values": ["Blue"]
+          }, {
+            "name": "Common Size",
+            "values": ["XXXL"]
+          }, {
+            "name": "Gender",
+            "values": ["Women"]
+          }, {
+            "name": "Made In Italy",
+            "values": ["No"]
+          }, {
+            "name": "Price",
+            "values": [497.5]
+          }, {
+            "name": "Size",
+            "values": ["58"]
+          }, {
+            "name": "Style",
+            "values": ["Business"]
+          }],
+          "url": "https://demo.commercetools.com/en/.html",
+          "variation_id": "M0E20000000DWKE"
+        },
+        "value": "Jacket Hogan dark blue"
+      }]
+    }],
+    "sort_options": [{
+      "display_name": "Relevance",
+      "sort_by": "relevance",
+      "sort_order": "descending",
+      "status": "selected"
+    }],
+    "total_num_results": 261
+  },
+  "result_id": "019997d2-f935-4020-9b8d-6b91b93cb5b2"
+}


### PR DESCRIPTION
All tests pass 👍 

#### Updates:
* Add Search Response test resource for variations
* Update Browse Response test resource with additional metadata/sort options
* Add support for sort options to Search and Browse response models
* Add support for variations to Result models
* Update `moveMetadataOutOfResultData` to handle variations as well