### PR TITLE
[CSL-843] Constructorio-java - Add Support for Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,40 @@ RecommendationsResponse response = constructor.recommendations(request, userInfo
 String response = constructor.recommendationsAsJSON(request, userInfo);
 ```
 
+# Retrieving All Tasks
+
+To retrieve all tasks, you will need to create a `AllTasksRequest`. In this request you can also specify the page and number of results per page. The page and number of results per page will default to 1 and 20 respectively.
+
+```java
+// Create a AllTasksRequest to request results for
+AllTasksRequest request = new AllTasksRequest();
+
+// Add in additional parameters
+request.setPage(2);
+request.setResultsPerPage(10);
+
+//Request all tasks as an object
+AllTasksResponse response = constructor.allTasks(request);
+
+//Request all tasks as a JSON string
+String response = constructor.allTasksAsJSON(request);
+```
+
+# Retrieving Task with task_id
+
+To retrieve a specific task with a task_id, you will need to create a `TaskRequest`.
+
+```java
+// Create a TaskRequest with the task_id to retrieve
+TaskRequest request = new TaskRequest("12345");
+
+//Request task as an object
+Task response = constructor.task(request);
+
+//Request task as a JSON string
+String response = constructor.taskAsJSON(request);
+```
+
 # Testing
 
 Download the repository and run the following commands from `./constructorio-client`
@@ -296,7 +330,6 @@ mvn clean               # clean target directory
 mvn install             # installs dependencies
 mvn test                # run tests
 mvn jacoco:report       # writes code coverage reports to ./target/site/jacoco
-mvn javadoc:javadoc     # generate docs
 ```
 
 # Environment Variables

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ mvn clean               # clean target directory
 mvn install             # installs dependencies
 mvn test                # run tests
 mvn jacoco:report       # writes code coverage reports to ./target/site/jacoco
+mvn javadoc:javadoc     # generate docs
 ```
 
 # Environment Variables

--- a/constructorio-client/src/main/java/io/constructor/client/AllTasksRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/AllTasksRequest.java
@@ -1,0 +1,47 @@
+package io.constructor.client;
+
+/**
+ * Constructor.io Get All Tasks Request
+ */
+public class AllTasksRequest {
+    private int resultsPerPage;
+    private int page;
+
+    /**
+     * Creates a All Tasks request
+     *
+     */
+    public AllTasksRequest() {
+        this.page = 1;
+        this.resultsPerPage = 20;
+    }
+
+    /**
+     * @param page the page of results to return
+     */
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    /**
+     * @return the page of results to return
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     * @param resultsPerPage the number of tasks to return - maximum value 100
+     */
+    public void setResultsPerPage(int resultsPerPage) {
+        this.resultsPerPage = resultsPerPage;
+    }
+
+    /**
+     * @return the results per page
+     */
+    public int getResultsPerPage() {
+        return resultsPerPage;
+    }
+
+}

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -13,11 +13,17 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.gson.Gson;
 
-import io.constructor.client.models.*;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import io.constructor.client.models.AutocompleteResponse;
+import io.constructor.client.models.BrowseResponse;
+import io.constructor.client.models.SearchResponse;
+import io.constructor.client.models.RecommendationsResponse;
+import io.constructor.client.models.ServerError;
+import io.constructor.client.models.AllTasksResponse;
+import io.constructor.client.models.Task;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.HttpUrl;

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -1364,6 +1364,7 @@ public class ConstructorIO {
      * Creates a All Tasks OkHttp request
      *
      * @param req the All Tasks request
+     * @param apiVersion version of api for url path
      * @return a All Tasks OkHttp request
      * @throws ConstructorException
      */
@@ -1391,7 +1392,6 @@ public class ConstructorIO {
     /**
      * Queries the tasks service for all tasks
      *
-     *
      * @param req the all tasks request
      * @return a all tasks response
      * @throws ConstructorException if the request is invalid.
@@ -1409,7 +1409,6 @@ public class ConstructorIO {
 
     /**
      * Queries the tasks service for all tasks
-     *
      *
      * @param req the all tasks request
      * @return a string of JSON
@@ -1429,6 +1428,7 @@ public class ConstructorIO {
      * Creates a Task OkHttp request
      *
      * @param req the Task request
+     * @param apiVersion version of api for url path
      * @return a Task OkHttp request
      * @throws ConstructorException
      */
@@ -1451,7 +1451,6 @@ public class ConstructorIO {
     /**
      * Queries the task service for a task id
      *
-     *
      * @param req the task request
      * @return a Task response
      * @throws ConstructorException if the request is invalid.
@@ -1469,7 +1468,6 @@ public class ConstructorIO {
 
     /**
      * Queries the task service for a task id
-     *
      *
      * @param req the task request
      * @return a string of JSON

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -1187,7 +1187,7 @@ public class ConstructorIO {
     }
 
     /**
-     * Transforms a JSON string to a new JSON string for easy Gson parsing into an recommendations response.
+     * Transforms a JSON string to a new JSON string for easy Gson parsing into an All Tasks response.
      * Using JSON objects to acheive this is considerably less error prone than attempting to do it in
      * a Gson Type Adapter.
      */
@@ -1198,7 +1198,7 @@ public class ConstructorIO {
     }
 
     /**
-     * Transforms a JSON string to a new JSON string for easy Gson parsing into an recommendations response.
+     * Transforms a JSON string to a new JSON string for easy Gson parsing into a Task response.
      * Using JSON objects to acheive this is considerably less error prone than attempting to do it in
      * a Gson Type Adapter.
      */

--- a/constructorio-client/src/main/java/io/constructor/client/TaskRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/TaskRequest.java
@@ -1,0 +1,38 @@
+package io.constructor.client;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * Constructor.io Get Task Request
+ */
+public class TaskRequest {
+    private String taskId;
+
+    /**
+     * Creates a Get Task request
+     *
+     * @param taskId the task_id to request
+     */
+    public TaskRequest(String taskId) {
+        if (taskId == null || taskId.isEmpty()) {
+            throw new IllegalArgumentException("task_id is required");
+        }
+        this.taskId = taskId;
+    }
+
+    /**
+     * @param taskId the task_id to request
+     */
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    /**
+     * @return the task_id to return
+     */
+    public String getTaskId() {
+        return taskId;
+    }
+
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/AllTasksResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/AllTasksResponse.java
@@ -1,0 +1,40 @@
+package io.constructor.client.models;
+
+import java.util.List;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Constructor.io All Tasks Response ... uses Gson/Reflection to load data in
+ */
+public class AllTasksResponse {
+
+    @SerializedName("total_count")
+    private int totalCount;
+
+    @SerializedName("tasks")
+    private List<Task> tasks;
+
+    @SerializedName("status_counts")
+    private StatusCounts statusCounts;
+
+    /**
+     * @return the total_count
+     */
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    /**
+     * @return the tasks
+     */
+    public List<Task> getTasks() {
+        return tasks;
+    }
+
+    /**
+     * @return the status_counts
+     */
+    public StatusCounts getStatusCounts() {
+        return statusCounts;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/StatusCounts.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/StatusCounts.java
@@ -22,16 +22,12 @@ public class StatusCounts {
     /**
      * @return the QUEUED status count
      */
-    public int getQueued() {
-        return queued;
-    }
+    public int getQueued() { return queued; }
 
     /**
      * @return the DONE status count
      */
-    public int getDone() {
-        return done;
-    }
+    public int getDone() { return done; }
 
     /**
      * @return the IN_PROGRESS status count

--- a/constructorio-client/src/main/java/io/constructor/client/models/StatusCounts.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/StatusCounts.java
@@ -1,0 +1,46 @@
+package io.constructor.client.models;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Constructor.io Status_Counts ... uses Gson/Reflection to load data in
+ */
+public class StatusCounts {
+
+    @SerializedName("QUEUED")
+    private int queued;
+
+    @SerializedName("DONE")
+    private int done;
+
+    @SerializedName("IN_PROGRESS")
+    private int inProgress;
+
+    @SerializedName("FAILED")
+    private int failed;
+
+    /**
+     * @return the QUEUED status count
+     */
+    public int getQueued() {
+        return queued;
+    }
+
+    /**
+     * @return the DONE status count
+     */
+    public int getDone() {
+        return done;
+    }
+
+    /**
+     * @return the IN_PROGRESS status count
+     */
+    public int getInProgress() { return inProgress; }
+
+    /**
+     * @return the FAILED status count
+     */
+    public int getFailed() { return failed; }
+
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/Task.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Task.java
@@ -22,9 +22,14 @@ public class Task {
     @SerializedName("last_update")
     private String lastUpdate;
 
+    @SerializedName("start_time")
+    private String startTime;
+
     @SerializedName("filename")
     private String filename;
 
+    @SerializedName("result")
+    private Object result;
 
     /**
      * @return the id
@@ -62,6 +67,20 @@ public class Task {
      */
     public String getFilename() {
         return filename;
+    }
+
+    /**
+     * @return the start_time
+     */
+    public String getStartTime() {
+        return startTime;
+    }
+
+    /**
+     * @return the result
+     */
+    public Object getResult() {
+        return result;
     }
 
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/Task.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Task.java
@@ -37,16 +37,12 @@ public class Task {
     /**
      * @return the id
      */
-    public int getId() {
-        return id;
-    }
+    public int getId() { return id; }
 
     /**
      * @return the type
      */
-    public String getType() {
-        return type;
-    }
+    public String getType() { return type; }
 
     /**
      * @return the status
@@ -61,36 +57,26 @@ public class Task {
     /**
      * @return the last_update
      */
-    public String getLastUpdate() {
-        return lastUpdate;
-    }
+    public String getLastUpdate() { return lastUpdate; }
 
     /**
      * @return the filename
      */
-    public String getFilename() {
-        return filename;
-    }
+    public String getFilename() { return filename; }
 
     /**
      * @return the start_time
      */
-    public String getStartTime() {
-        return startTime;
-    }
+    public String getStartTime() { return startTime; }
 
     /**
      * @return the protocol
      */
-    public String getProtocol() {
-        return protocol;
-    }
+    public String getProtocol() { return protocol; }
 
     /**
      * @return the result
      */
-    public Object getResult() {
-        return result;
-    }
+    public Object getResult() { return result; }
 
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/Task.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Task.java
@@ -1,0 +1,67 @@
+package io.constructor.client.models;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Constructor.io Task ... uses Gson/Reflection to load data in
+ */
+public class Task {
+
+    @SerializedName("id")
+    private int id;
+
+    @SerializedName("type")
+    private String type;
+
+    @SerializedName("status")
+    private String status;
+
+    @SerializedName("submission_time")
+    private String submissionTime;
+
+    @SerializedName("last_update")
+    private String lastUpdate;
+
+    @SerializedName("filename")
+    private String filename;
+
+
+    /**
+     * @return the id
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return the status
+     */
+    public String getStatus() { return status; }
+
+    /**
+     * @return the submission_time
+     */
+    public String getSubmissionTime() { return submissionTime; }
+
+    /**
+     * @return the last_update
+     */
+    public String getLastUpdate() {
+        return lastUpdate;
+    }
+
+    /**
+     * @return the filename
+     */
+    public String getFilename() {
+        return filename;
+    }
+
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/Task.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Task.java
@@ -28,6 +28,9 @@ public class Task {
     @SerializedName("filename")
     private String filename;
 
+    @SerializedName("protocol")
+    private String protocol;
+
     @SerializedName("result")
     private Object result;
 
@@ -74,6 +77,13 @@ public class Task {
      */
     public String getStartTime() {
         return startTime;
+    }
+
+    /**
+     * @return the protocol
+     */
+    public String getProtocol() {
+        return protocol;
     }
 
     /**

--- a/constructorio-client/src/test/java/io/constructor/client/AllTasksRequestTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/AllTasksRequestTest.java
@@ -1,0 +1,33 @@
+package io.constructor.client;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class AllTasksRequestTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void newShouldReturnTaskRequestWithDefaults() throws Exception {
+        AllTasksRequest request = new AllTasksRequest();
+        assertEquals(20, request.getResultsPerPage());
+        assertEquals( 1, request.getPage());
+    }
+
+    @Test
+    public void settersShouldSet() throws Exception {
+        AllTasksRequest request = new AllTasksRequest();
+        assertEquals(20, request.getResultsPerPage());
+        assertEquals( 1, request.getPage());
+
+        request.setPage(5);
+        request.setResultsPerPage(50);
+
+        assertEquals(50, request.getResultsPerPage());
+        assertEquals(5, request.getPage());
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/AllTasksResponseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/AllTasksResponseTest.java
@@ -1,0 +1,29 @@
+package io.constructor.client;
+
+import io.constructor.client.models.AllTasksResponse;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+
+public class AllTasksResponseTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void createAllTaskResponseShouldReturnAResult() throws Exception {
+        String string = Utils.getTestResource("response.alltasks.json");
+        AllTasksResponse response = ConstructorIO.createAllTasksResponse(string);
+
+        assertEquals("20 tasks exists", 20, response.getTasks().size());
+        assertEquals("total_count exists", 4733, response.getTotalCount());
+        assertEquals("status_count - QUEUED exists", 6, response.getStatusCounts().getQueued());
+        assertEquals("status_count - IN_PROGRESS exists", 0, response.getStatusCounts().getInProgress());
+        assertEquals("status_count - DONE exists", 20, response.getStatusCounts().getDone());
+        assertEquals("status_count - FAILED exists", 0, response.getStatusCounts().getFailed());
+    }
+
+}

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTaskTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTaskTest.java
@@ -1,6 +1,5 @@
 package io.constructor.client;
 
-import io.constructor.client.models.AllTasksResponse;
 import io.constructor.client.models.Task;
 import org.apache.commons.io.FileUtils;
 import org.json.JSONObject;

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTaskTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTaskTest.java
@@ -1,0 +1,115 @@
+package io.constructor.client;
+
+import io.constructor.client.models.AllTasksResponse;
+import io.constructor.client.models.Task;
+import org.apache.commons.io.FileUtils;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ConstructorIOTaskTest {
+
+    private String apiKey = System.getenv("TEST_API_KEY");
+    private String apiToken = System.getenv("TEST_API_TOKEN");
+    private File csvFolder = new File("src/test/resources/csv");
+    private File itemsFile = new File("src/test/resources/csv/items.csv");
+    private String baseUrl = "https://raw.githubusercontent.com/Constructor-io/integration-examples/main/catalog/";
+    private int task_id = 0;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void init() throws Exception{
+        URL itemsUrl = new URL(baseUrl + "items.csv");
+        FileUtils.copyURLToFile(itemsUrl, itemsFile);
+
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        Map<String, File> files = new HashMap<String, File>();
+
+        files.put("items", new File("src/test/resources/csv/items.csv"));
+
+        CatalogRequest req = new CatalogRequest(files, "Products");
+        String response = constructor.replaceCatalog(req);
+        JSONObject jsonObj = new JSONObject(response);
+
+        task_id = jsonObj.getInt("task_id");
+    }
+
+    @After
+    public void teardown() throws Exception{
+        itemsFile.delete();
+        csvFolder.delete();
+    }
+
+    @Test
+    public void TaskShouldRetrieveTaskGivenTaskId() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        TaskRequest request = new TaskRequest(String.valueOf(task_id));
+        Task response = constructor.task(request);
+
+        assertEquals("Returns the same Task Id", task_id, response.getId());
+    }
+
+    @Test
+    public void TaskAsJSONShouldRetrieveTaskGivenTaskId() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        TaskRequest request = new TaskRequest(String.valueOf(task_id));
+        String response = constructor.taskAsJson(request);
+        JSONObject jsonObject = new JSONObject(response);
+        int respTaskId = jsonObject.getInt("id");
+
+        assertEquals("Returns the same Task Id", task_id, respTaskId);
+    }
+
+    @Test
+    public void TaskRequestWithInvalidTokenShouldError() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("notavalidtoken", apiKey, true, null);
+        TaskRequest request = new TaskRequest(String.valueOf(task_id));
+
+        thrown.expect(ConstructorException.class);
+        thrown.expectMessage("[HTTP 401] Invalid auth_token. If you've forgotten your token, you can generate a new one at app.constructor.io/dashboard");
+        Task response = constructor.task(request);
+    }
+
+    @Test
+    public void TaskAsJSONRequestWithInvalidTokenShouldError() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("notavalidtoken", apiKey, true, null);
+        TaskRequest request = new TaskRequest(String.valueOf(task_id));
+
+        thrown.expect(ConstructorException.class);
+        thrown.expectMessage("[HTTP 401] Invalid auth_token. If you've forgotten your token, you can generate a new one at app.constructor.io/dashboard");
+        String response = constructor.taskAsJson(request);
+    }
+
+    @Test
+    public void TaskRequestWithInvalidApiKeyShouldError() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, "notavalidkey", true, null);
+        TaskRequest request = new TaskRequest(String.valueOf(task_id));
+
+        thrown.expect(ConstructorException.class);
+        thrown.expectMessage("[HTTP 400] We have no record of this key. You can find your key at app.constructor.io/dashboard.");
+        Task response = constructor.task(request);
+    }
+
+    @Test
+    public void TaskAsJSONRequestWithInvalidApiKeyShouldError() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, "notavalidkey", true, null);
+        TaskRequest request = new TaskRequest(String.valueOf(task_id));
+
+        thrown.expect(ConstructorException.class);
+        thrown.expectMessage("[HTTP 400] We have no record of this key. You can find your key at app.constructor.io/dashboard.");
+        String response = constructor.taskAsJson(request);
+    }
+
+}

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTasksTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTasksTest.java
@@ -86,7 +86,7 @@ public class ConstructorIOTasksTest {
         }).findAny().orElse(null);
 
         assertTrue("At least one task exists", response.getTotalCount() >= 1);
-        assertTrue("Previously uploaded task_id exists", task != null);
+        assertNotNull("Previously uploaded task_id exists", task);
     }
 
     @Test
@@ -109,55 +109,47 @@ public class ConstructorIOTasksTest {
         }
 
         assertTrue("At least one task exists", jsonObj.getInt("total_count") >= 1);
-        assertTrue("Previously uploaded task_id exists", task != null);
+        assertNotNull("Previously uploaded task_id exists", task);
     }
 
     @Test
     public void AllTasksShouldReturnErrorWithInvalidApiKey() throws Exception {
-        try {
-            ConstructorIO constructor = new ConstructorIO(apiToken, "notanapikey", true, null);
-            AllTasksRequest request = new AllTasksRequest();
-            AllTasksResponse response = constructor.allTasks(request);
-        } catch (ConstructorException e)
-        {
-            assertEquals("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.", e.getCause().getMessage());
-        }
+        ConstructorIO constructor = new ConstructorIO(apiToken, "notanapikey", true, null);
+        AllTasksRequest request = new AllTasksRequest();
+
+        thrown.expect(ConstructorException.class);
+        thrown.expectMessage("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.");
+        AllTasksResponse response = constructor.allTasks(request);
     }
 
     @Test
     public void AllTasksShouldReturnErrorWithInvalidApiToken() throws Exception {
-        try {
-            ConstructorIO constructor = new ConstructorIO("notanapitoken", apiKey, true, null);
-            AllTasksRequest request = new AllTasksRequest();
-            AllTasksResponse response = constructor.allTasks(request);
-        } catch (ConstructorException e)
-        {
-            assertEquals("[HTTP 401] Invalid auth_token. If you've forgotten your token, you can generate a new one at app.constructor.io/dashboard", e.getCause().getMessage());
-        }
+        ConstructorIO constructor = new ConstructorIO("notanapitoken", apiKey, true, null);
+        AllTasksRequest request = new AllTasksRequest();
+
+        thrown.expect(ConstructorException.class);
+        thrown.expectMessage("[HTTP 401] Invalid auth_token. If you've forgotten your token, you can generate a new one at app.constructor.io/dashboard");
+        AllTasksResponse response = constructor.allTasks(request);
     }
 
     @Test
     public void AllTasksAsJSONShouldReturnErrorWithInvalidApiKey() throws Exception {
-        try {
-            ConstructorIO constructor = new ConstructorIO(apiToken, "notanapikey", true, null);
-            AllTasksRequest request = new AllTasksRequest();
-            String response = constructor.allTasksAsJson(request);
-        } catch (ConstructorException e)
-        {
-            assertEquals("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.", e.getCause().getMessage());
-        }
+        ConstructorIO constructor = new ConstructorIO(apiToken, "notanapikey", true, null);
+        AllTasksRequest request = new AllTasksRequest();
+
+        thrown.expect(ConstructorException.class);
+        thrown.expectMessage("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.");
+        String response = constructor.allTasksAsJson(request);
     }
 
     @Test
     public void AllTasksAsJSONShouldReturnErrorWithInvalidApiToken() throws Exception {
-        try {
-            ConstructorIO constructor = new ConstructorIO("notanapitoken", apiKey, true, null);
-            AllTasksRequest request = new AllTasksRequest();
-            String response = constructor.allTasksAsJson(request);
-        } catch (ConstructorException e)
-        {
-            assertEquals("[HTTP 401] Invalid auth_token. If you've forgotten your token, you can generate a new one at app.constructor.io/dashboard", e.getCause().getMessage());
-        }
+        ConstructorIO constructor = new ConstructorIO("notanapitoken", apiKey, true, null);
+        AllTasksRequest request = new AllTasksRequest();
+
+        thrown.expect(ConstructorException.class);
+        thrown.expectMessage("[HTTP 401] Invalid auth_token. If you've forgotten your token, you can generate a new one at app.constructor.io/dashboard");
+        String response = constructor.allTasksAsJson(request);
     }
 
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTasksTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTasksTest.java
@@ -1,0 +1,163 @@
+package io.constructor.client;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import io.constructor.client.models.AllTasksResponse;
+import io.constructor.client.models.Task;
+import org.apache.commons.io.FileUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+import static org.junit.Assert.*;
+
+public class ConstructorIOTasksTest {
+
+    private String apiKey = System.getenv("TEST_API_KEY");
+    private String apiToken = System.getenv("TEST_API_TOKEN");
+    private File csvFolder = new File("src/test/resources/csv");
+    private File itemsFile = new File("src/test/resources/csv/items.csv");
+    private String baseUrl = "https://raw.githubusercontent.com/Constructor-io/integration-examples/main/catalog/";
+    private int task_id = 0;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void init() throws Exception{
+        URL itemsUrl = new URL(baseUrl + "items.csv");
+        FileUtils.copyURLToFile(itemsUrl, itemsFile);
+
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        Map<String, File> files = new HashMap<String, File>();
+
+        files.put("items", new File("src/test/resources/csv/items.csv"));
+
+        CatalogRequest req = new CatalogRequest(files, "Products");
+        String response = constructor.replaceCatalog(req);
+        JSONObject jsonObj = new JSONObject(response);
+
+        task_id = jsonObj.getInt("task_id");
+    }
+
+    @After
+    public void teardown() throws Exception{
+        itemsFile.delete();
+        csvFolder.delete();
+    }
+
+    @Test
+    public void AllTasksAsJSONShouldReturnAResult() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        AllTasksRequest request = new AllTasksRequest();
+        String response = constructor.allTasksAsJson(request);
+        assertFalse("Returns a response", response.isEmpty());
+    }
+
+    @Test
+    public void AllTasksShouldReturnAResult() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        AllTasksRequest request = new AllTasksRequest();
+        AllTasksResponse response = constructor.allTasks(request);
+        assertNotNull("Returns a response", response);
+    }
+
+    @Test
+    public void AllTasksShouldReturnAListOfTasks() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        AllTasksRequest request = new AllTasksRequest();
+        AllTasksResponse response = constructor.allTasks(request);
+
+        Task task = response.getTasks().stream().filter(new Predicate<Task>() {
+            @Override
+            public boolean test(Task t) {
+                return t.getId() == task_id;
+            }
+        }).findAny().orElse(null);
+
+        assertTrue("At least one task exists", response.getTotalCount() >= 1);
+        assertTrue("Previously uploaded task_id exists", task != null);
+    }
+
+    @Test
+    public void AllTasksAsJSONShouldReturnAListOfTasks() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        AllTasksRequest request = new AllTasksRequest();
+        String response = constructor.allTasksAsJson(request);
+        JSONObject jsonObj = new JSONObject(response);
+
+        JSONArray tasksArray = jsonObj.getJSONArray("tasks");
+        JSONObject task = null;
+
+        for(int i = 0; i < tasksArray.length(); i++)
+        {
+            JSONObject obj = tasksArray.getJSONObject(i);
+            if (obj.getInt("id") == task_id)
+            {
+                task = obj;
+            }
+        }
+
+        assertTrue("At least one task exists", jsonObj.getInt("total_count") >= 1);
+        assertTrue("Previously uploaded task_id exists", task != null);
+    }
+
+    @Test
+    public void AllTasksShouldReturnErrorWithInvalidApiKey() throws Exception {
+        try {
+            ConstructorIO constructor = new ConstructorIO(apiToken, "notanapikey", true, null);
+            AllTasksRequest request = new AllTasksRequest();
+            AllTasksResponse response = constructor.allTasks(request);
+        } catch (ConstructorException e)
+        {
+            assertEquals("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void AllTasksShouldReturnErrorWithInvalidApiToken() throws Exception {
+        try {
+            ConstructorIO constructor = new ConstructorIO("notanapitoken", apiKey, true, null);
+            AllTasksRequest request = new AllTasksRequest();
+            AllTasksResponse response = constructor.allTasks(request);
+        } catch (ConstructorException e)
+        {
+            assertEquals("[HTTP 401] Invalid auth_token. If you've forgotten your token, you can generate a new one at app.constructor.io/dashboard", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void AllTasksAsJSONShouldReturnErrorWithInvalidApiKey() throws Exception {
+        try {
+            ConstructorIO constructor = new ConstructorIO(apiToken, "notanapikey", true, null);
+            AllTasksRequest request = new AllTasksRequest();
+            String response = constructor.allTasksAsJson(request);
+        } catch (ConstructorException e)
+        {
+            assertEquals("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.", e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void AllTasksAsJSONShouldReturnErrorWithInvalidApiToken() throws Exception {
+        try {
+            ConstructorIO constructor = new ConstructorIO("notanapitoken", apiKey, true, null);
+            AllTasksRequest request = new AllTasksRequest();
+            String response = constructor.allTasksAsJson(request);
+        } catch (ConstructorException e)
+        {
+            assertEquals("[HTTP 401] Invalid auth_token. If you've forgotten your token, you can generate a new one at app.constructor.io/dashboard", e.getCause().getMessage());
+        }
+    }
+
+}

--- a/constructorio-client/src/test/java/io/constructor/client/TaskRequestTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/TaskRequestTest.java
@@ -1,0 +1,36 @@
+package io.constructor.client;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TaskRequestTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void newWithNullTaskIdShouldFail() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        new TaskRequest(null);
+    }
+
+    @Test
+    public void newShouldReturnTaskRequest() throws Exception {
+        String taskId = "320";
+        TaskRequest request = new TaskRequest(taskId);
+        assertEquals(request.getTaskId(), taskId);
+    }
+
+    @Test
+    public void settersShouldSet() throws Exception {
+        String taskId = "320";
+        TaskRequest request = new TaskRequest(taskId);
+        assertEquals(request.getTaskId(), taskId);
+
+        request.setTaskId("322");
+        assertEquals(request.getTaskId(), "322");
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/TaskResponseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/TaskResponseTest.java
@@ -1,0 +1,55 @@
+package io.constructor.client;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.constructor.client.models.Task;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+
+public class TaskResponseTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void createTaskResponseWithQueuedTaskShouldReturnAResult() throws Exception {
+        String string = Utils.getTestResource("response.task.queued.json");
+        Task response = ConstructorIO.createTaskResponse(string);
+
+        assertEquals("id exists", 0, response.getId());
+        assertEquals("status exists", "QUEUED", response.getStatus());
+        assertEquals("submission_time exists", "2020-04-24T15:06:27Z", response.getSubmissionTime());
+        assertNull(response.getProtocol());
+        assertNull(response.getLastUpdate());
+        assertNull(response.getFilename());
+        assertNull(response.getStartTime());
+        assertNull(response.getType());
+        assertNull(response.getResult());
+    }
+
+    @Test
+    public void createTaskResponseWithDoneTaskShouldReturnAResult() throws Exception {
+        String string = Utils.getTestResource("response.task.done.json");
+        Task response = ConstructorIO.createTaskResponse(string);
+        JsonObject jsonObj = new Gson().toJsonTree(response.getResult()).getAsJsonObject();
+
+        assertEquals("id exists", 0, response.getId());
+        assertEquals("status exists", "DONE", response.getStatus());
+        assertEquals("submission_time exists", "2020-04-24T15:06:27Z", response.getSubmissionTime());
+        assertEquals("last_update exists", "2020-04-24T15:08:27Z", response.getLastUpdate());
+        assertEquals("start_time exists", "2020-04-24T15:07:27Z", response.getStartTime());
+        assertNotNull("changelog exists", jsonObj.getAsJsonObject("changelog"));
+        assertNotNull("sections exists", jsonObj.getAsJsonObject("changelog").getAsJsonObject("sections"));
+        assertNotNull("Products exists", jsonObj.getAsJsonObject("changelog").getAsJsonObject("sections").getAsJsonObject("Products"));
+        assertEquals("items_updated exists",10, jsonObj.getAsJsonObject("changelog").getAsJsonObject("sections").getAsJsonObject("Products").get("items_updated").getAsInt());
+        assertEquals("items_deleted exists",0, jsonObj.getAsJsonObject("changelog").getAsJsonObject("sections").getAsJsonObject("Products").get("items_deleted").getAsInt());
+        assertEquals("variations_updated exists",20, jsonObj.getAsJsonObject("changelog").getAsJsonObject("sections").getAsJsonObject("Products").get("variations_updated").getAsInt());
+        assertEquals("variations_deleted exists",5, jsonObj.getAsJsonObject("changelog").getAsJsonObject("sections").getAsJsonObject("Products").get("variations_deleted").getAsInt());
+        assertEquals("index_built exists",true, jsonObj.getAsJsonObject("changelog").get("index_built").getAsBoolean());
+    }
+
+}

--- a/constructorio-client/src/test/resources/response.alltasks.json
+++ b/constructorio-client/src/test/resources/response.alltasks.json
@@ -1,0 +1,431 @@
+{
+  "tasks": [
+    {
+      "id": 30963447,
+      "status": "DONE",
+      "submission_time": "2022-01-06T04:50:55Z",
+      "last_update": "2022-01-06T04:50:59Z",
+      "start_time": "2022-01-06T04:50:57Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-04-50-55.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958468,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:50:17Z",
+      "last_update": "2022-01-06T00:50:26Z",
+      "start_time": "2022-01-06T00:50:24Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-50-17.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958467,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:50:16Z",
+      "last_update": "2022-01-06T00:50:23Z",
+      "start_time": "2022-01-06T00:50:21Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-50-13.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958466,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:50:07Z",
+      "last_update": "2022-01-06T00:50:20Z",
+      "start_time": "2022-01-06T00:50:18Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-50-06.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958462,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:50:05Z",
+      "last_update": "2022-01-06T00:50:17Z",
+      "start_time": "2022-01-06T00:50:14Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-50-04.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958460,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:50:03Z",
+      "last_update": "2022-01-06T00:50:14Z",
+      "start_time": "2022-01-06T00:50:11Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-50-03.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958459,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:50:02Z",
+      "last_update": "2022-01-06T00:50:11Z",
+      "start_time": "2022-01-06T00:50:09Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-50-02.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958457,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:50:01Z",
+      "last_update": "2022-01-06T00:50:08Z",
+      "start_time": "2022-01-06T00:50:06Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-50-00.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958455,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:49:59Z",
+      "last_update": "2022-01-06T00:50:05Z",
+      "start_time": "2022-01-06T00:50:03Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-49-59.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958453,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:49:57Z",
+      "last_update": "2022-01-06T00:50:02Z",
+      "start_time": "2022-01-06T00:50:00Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-49-56.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958452,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:49:54Z",
+      "last_update": "2022-01-06T00:49:59Z",
+      "start_time": "2022-01-06T00:49:57Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-49-54.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958451,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:49:51Z",
+      "last_update": "2022-01-06T00:49:56Z",
+      "start_time": "2022-01-06T00:49:54Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-49-51.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958448,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:49:49Z",
+      "last_update": "2022-01-06T00:49:53Z",
+      "start_time": "2022-01-06T00:49:50Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-49-48.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958443,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:49:45Z",
+      "last_update": "2022-01-06T00:49:46Z",
+      "start_time": "2022-01-06T00:49:46Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-49-45.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958441,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:49:42Z",
+      "last_update": "2022-01-06T00:49:43Z",
+      "start_time": "2022-01-06T00:49:43Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-49-41.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958392,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:47:22Z",
+      "last_update": "2022-01-06T00:47:25Z",
+      "start_time": "2022-01-06T00:47:23Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-47-21.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958391,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:47:19Z",
+      "last_update": "2022-01-06T00:47:22Z",
+      "start_time": "2022-01-06T00:47:19Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-47-18.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958389,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:47:15Z",
+      "last_update": "2022-01-06T00:47:17Z",
+      "start_time": "2022-01-06T00:47:16Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-47-14.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958384,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:47:09Z",
+      "last_update": "2022-01-06T00:47:11Z",
+      "start_time": "2022-01-06T00:47:10Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-47-09.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    },
+    {
+      "id": 30958382,
+      "status": "DONE",
+      "submission_time": "2022-01-06T00:47:06Z",
+      "last_update": "2022-01-06T00:47:07Z",
+      "start_time": "2022-01-06T00:47:07Z",
+      "result": {
+        "changelog": {
+          "sections": {
+            "Products": {
+              "items_updated": 11,
+              "items_deleted": 0
+            }
+          }
+        },
+        "index_built": true
+      },
+      "filename": "ZqXaOfXuBWD4s3XzCI1q_Products_sync_2022-01-06-00-47-05.tar",
+      "type": "ingestion",
+      "protocol": "http"
+    }
+  ],
+  "total_count": 4733,
+  "status_counts": {
+    "QUEUED": 6,
+    "IN_PROGRESS": 0,
+    "DONE": 20,
+    "FAILED": 0
+  }
+}

--- a/constructorio-client/src/test/resources/response.task.done.json
+++ b/constructorio-client/src/test/resources/response.task.done.json
@@ -1,0 +1,20 @@
+{
+  "id": 0,
+  "status": "DONE",
+  "submission_time": "2020-04-24T15:06:27Z",
+  "last_update": "2020-04-24T15:08:27Z",
+  "start_time": "2020-04-24T15:07:27Z",
+  "result": {
+    "changelog": {
+      "sections": {
+        "Products": {
+          "items_updated": 10,
+          "items_deleted": 0,
+          "variations_updated": 20,
+          "variations_deleted": 5
+        }
+      },
+      "index_built": true
+    }
+  }
+}

--- a/constructorio-client/src/test/resources/response.task.queued.json
+++ b/constructorio-client/src/test/resources/response.task.queued.json
@@ -1,0 +1,7 @@
+{
+  "id": 0,
+  "status": "QUEUED",
+  "submission_time": "2020-04-24T15:06:27Z",
+  "last_update": null,
+  "start_time": null
+}


### PR DESCRIPTION
Added Task/AllTasks methods. 

To only test the new methods run:
`mvn -Dtest=ConstructorIOTasksTest,ConstructorIOTaskTest test`
in the constructorio-client directory.


