### PR TITLE
[CSL 990] Add support for hidden facets

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ request.setSortBy("Price");
 request.setSortAscending(true);
 request.getFacets().put("Brand", Arrays.asList("Jif"))
 
+// Add the following paramaters to request for hidden fields or facets
+request.getHiddenFields().add("hidden_price_field");
+request.getHiddenFacets().add("hidden_brand_facet");
+
 // Create a UserInfo object with the session and unique device identifier (optional)
 UserInfo userInfo = new UserInfo(5, "device-id-1123123");
 userInfo.setUserSegments(Arrays.asList("Desktop", "Chrome"));
@@ -205,6 +209,10 @@ request.setSortBy("Price");
 request.setSortAscending(true);
 request.getFacets().put("Brand", Arrays.asList("Jif"))
 
+// Add the following paramaters to request for hidden fields or facets
+request.getHiddenFields().add("hidden_price_field");
+request.getHiddenFacets().add("hidden_brand_facet");
+
 // Create a UserInfo object with the session and unique device identifier (optional)
 UserInfo userInfo = new UserInfo(5, "device-id-1123123");
 userInfo.setUserSegments(Arrays.asList("Desktop", "Chrome"));
@@ -247,6 +255,10 @@ request.setGroupId("625");r
 request.setSortBy("Price");
 request.setSortAscending(true);
 request.getFacets().put("Brand", Arrays.asList("Jif"))
+
+// Add the following paramaters to request for hidden fields or facets
+request.getHiddenFields().add("hidden_price_field");
+request.getHiddenFacets().add("hidden_brand_facet");
 
 // Create a UserInfo object with the session and unique device identifier (optional)
 UserInfo userInfo = new UserInfo(5, "device-id-1123123");

--- a/constructorio-client/src/main/java/io/constructor/client/BrowseItemsRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/BrowseItemsRequest.java
@@ -20,6 +20,7 @@ public class BrowseItemsRequest {
     private boolean sortAscending;
     private Map<String, String>formatOptions;
     private List<String> hiddenFields;
+    private List<String> hiddenFacets;
     
     /**
      * Creates a browse request
@@ -39,6 +40,7 @@ public class BrowseItemsRequest {
       this.sortAscending = true;
       this.formatOptions = new HashMap<String, String>();
       this.hiddenFields = new ArrayList<String>();
+      this.hiddenFacets = new ArrayList<String>();
     }
 
     /**
@@ -171,13 +173,27 @@ public class BrowseItemsRequest {
      * @param hiddenFields the hiddenFields to set
      */
     public void setHiddenFields(List<String> hiddenFields) {
-        this.hiddenFields = hiddenFields;
+      this.hiddenFields = hiddenFields;
     }
 
     /**
      * @return the hidden fields
      */
     public List<String> getHiddenFields() {
-        return hiddenFields;
+      return hiddenFields;
+    }
+
+    /**
+     * @param hiddenFacets the hiddenFacets to set
+     */
+    public void setHiddenFacets(List<String> hiddenFacets) {
+      this.hiddenFacets = hiddenFacets;
+    }
+
+    /**
+     * @return the hidden facets
+     */
+    public List<String> getHiddenFacets() {
+      return hiddenFacets;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/BrowseRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/BrowseRequest.java
@@ -21,6 +21,7 @@ public class BrowseRequest {
     private boolean sortAscending;
     private Map<String, String>formatOptions;
     private List<String> hiddenFields;
+    private List<String> hiddenFacets;
     
     /**
      * Creates a browse request
@@ -45,6 +46,7 @@ public class BrowseRequest {
       this.sortAscending = true;
       this.formatOptions = new HashMap<String, String>();
       this.hiddenFields = new ArrayList<String>();
+      this.hiddenFacets = new ArrayList<String>();
     }
 
     /**
@@ -199,5 +201,19 @@ public class BrowseRequest {
      */
     public List<String> getHiddenFields() {
       return hiddenFields;
+    }
+
+    /**
+     * @param hiddenFacets the hiddenFacets to set
+     */
+    public void setHiddenFacets(List<String> hiddenFacets) {
+      this.hiddenFacets = hiddenFacets;
+    }
+
+    /**
+     * @return the hidden facets
+     */
+    public List<String> getHiddenFacets() {
+      return hiddenFacets;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -490,7 +490,13 @@ public class ConstructorIO {
 
             for (String hiddenField : req.getHiddenFields()) {
                 url = url.newBuilder()
-                    .addQueryParameter("hidden_fields", hiddenField)
+                    .addQueryParameter("fmt_options[hidden_fields]", hiddenField)
+                    .build();
+            }
+
+            for (String hiddenFacet : req.getHiddenFacets()) {
+                url = url.newBuilder()
+                    .addQueryParameter("fmt_options[hidden_facets]", hiddenFacet)
                     .build();
             }
 
@@ -638,7 +644,13 @@ public class ConstructorIO {
 
             for (String hiddenField : req.getHiddenFields()) {
                 url = url.newBuilder()
-                    .addQueryParameter("hidden_fields", hiddenField)
+                    .addQueryParameter("fmt_options[hidden_fields]", hiddenField)
+                    .build();
+            }
+
+            for (String hiddenFacet : req.getHiddenFacets()) {
+                url = url.newBuilder()
+                    .addQueryParameter("fmt_options[hidden_facets]", hiddenFacet)
                     .build();
             }
 
@@ -793,7 +805,13 @@ public class ConstructorIO {
 
             for (String hiddenField : req.getHiddenFields()) {
                 url = url.newBuilder()
-                        .addQueryParameter("hidden_fields", hiddenField)
+                        .addQueryParameter("fmt_options[hidden_fields]", hiddenField)
+                        .build();
+            }
+
+            for (String hiddenFacet : req.getHiddenFacets()) {
+                url = url.newBuilder()
+                        .addQueryParameter("fmt_options[hidden_facets]", hiddenFacet)
                         .build();
             }
 

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -805,14 +805,14 @@ public class ConstructorIO {
 
             for (String hiddenField : req.getHiddenFields()) {
                 url = url.newBuilder()
-                        .addQueryParameter("fmt_options[hidden_fields]", hiddenField)
-                        .build();
+                    .addQueryParameter("fmt_options[hidden_fields]", hiddenField)
+                    .build();
             }
 
             for (String hiddenFacet : req.getHiddenFacets()) {
                 url = url.newBuilder()
-                        .addQueryParameter("fmt_options[hidden_facets]", hiddenFacet)
-                        .build();
+                    .addQueryParameter("fmt_options[hidden_facets]", hiddenFacet)
+                    .build();
             }
 
             Request request = this.makeUserRequestBuilder(userInfo)

--- a/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
@@ -21,6 +21,7 @@ public class SearchRequest {
     private String collectionId;
     private Map<String, String>formatOptions;
     private List<String> hiddenFields;
+    private List<String> hiddenFacets;
 
     /**
      * Creates a search request
@@ -40,6 +41,7 @@ public class SearchRequest {
       this.sortAscending = true;
       this.formatOptions = new HashMap<String, String>();
       this.hiddenFields = new ArrayList<String>();
+      this.hiddenFacets = new ArrayList<String>();
     }
 
     /**
@@ -194,5 +196,19 @@ public class SearchRequest {
      */
     public List<String> getHiddenFields() {
       return hiddenFields;
+    }
+
+    /**
+     * @param hiddenFacets the hiddenFacets to set
+     */
+    public void setHiddenFacets(List<String> hiddenFacets) {
+      this.hiddenFacets = hiddenFacets;
+    }
+
+    /**
+     * @return the hidden facets
+     */
+    public List<String> getHiddenFacets() {
+      return hiddenFacets;
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/BrowseItemsRequestTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/BrowseItemsRequestTest.java
@@ -47,6 +47,7 @@ public class BrowseItemsRequestTest {
         Map<String, String> formatOptions = new HashMap<String, String>();
         formatOptions.put("groups_start", "top");
         List<String> hiddenFields = Arrays.asList("hiddenField1", "hiddenField2");
+        List<String> hiddenFacets = Arrays.asList("hiddenFacet1", "hiddenFacet2");
         
         request.setIds(newIds);
         request.setSection("Browse Suggestions");
@@ -58,6 +59,7 @@ public class BrowseItemsRequestTest {
         request.setSortAscending(false);
         request.setFormatOptions(formatOptions);
         request.setHiddenFields(hiddenFields);
+        request.setHiddenFacets(hiddenFacets);
 
         assertEquals(request.getIds(), newIds);
         assertEquals(request.getSection(), "Browse Suggestions");
@@ -69,5 +71,6 @@ public class BrowseItemsRequestTest {
         assertEquals(request.getSortAscending(), false);
         assertEquals(request.getFormatOptions(), formatOptions);
         assertEquals(request.getHiddenFields(), hiddenFields);
+        assertEquals(request.getHiddenFacets(), hiddenFacets);
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/BrowseRequestTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/BrowseRequestTest.java
@@ -59,6 +59,7 @@ public class BrowseRequestTest {
         Map<String, String> formatOptions = new HashMap<String, String>();
         formatOptions.put("groups_start", "top");
         List<String> hiddenFields = Arrays.asList("hiddenField1", "hiddenField2");
+        List<String> hiddenFacets = Arrays.asList("hiddenFacet1", "hiddenFacet2");
         
         request.setFilterName("VacationType");
         request.setFilterValue("Air Travel");
@@ -71,6 +72,7 @@ public class BrowseRequestTest {
         request.setSortAscending(false);
         request.setFormatOptions(formatOptions);
         request.setHiddenFields(hiddenFields);
+        request.setHiddenFacets(hiddenFacets);
 
         assertEquals(request.getFilterName(), "VacationType");
         assertEquals(request.getFilterValue(), "Air Travel");
@@ -83,5 +85,7 @@ public class BrowseRequestTest {
         assertEquals(request.getSortAscending(), false);
         assertEquals(request.getFormatOptions(), formatOptions);
         assertEquals(request.getHiddenFields(), hiddenFields);
+        assertEquals(request.getHiddenFacets(), hiddenFacets);
+
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseItemsTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseItemsTest.java
@@ -1,16 +1,19 @@
 package io.constructor.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import io.constructor.client.models.BrowseResponse;
+import io.constructor.client.models.FilterFacet;
 import io.constructor.client.models.FilterGroup;
 
 public class ConstructorIOBrowseItemsTest {
@@ -197,5 +200,26 @@ public class ConstructorIOBrowseItemsTest {
         assertTrue("browse items total results count should be equal to length of supplied ids", (int)response.getResponse().getTotalNumberOfResults() == ids.size());
         assertTrue("browse items result id exists", response.getResultId() != null);
         assertEquals("browse items [testField] exists", response.getResponse().getResults().get(0).getData().getMetadata().get("testField"), "hiddenFieldValue");
+    }
+
+    @Test
+    public void BrowseItemsShouldReturnAResultWithHiddenFacets() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        List<String> ids = Arrays.asList("10001", "10002");
+        BrowseItemsRequest request = new BrowseItemsRequest(ids);
+        request.getHiddenFacets().add("Brand");
+        BrowseResponse response = constructor.browseItems(request, userInfo);
+        FilterFacet brandFacet = response.getResponse().getFacets().stream().filter(new Predicate<FilterFacet>() {
+            @Override
+            public boolean test(FilterFacet f) {
+                return f.getName().equals("Brand");
+            }
+        }).findAny().orElse(null);
+
+        assertTrue("browse items results exist", response.getResponse().getResults().size() > 0);
+        assertTrue("browse items total results count should be equal to length of supplied ids", (int)response.getResponse().getTotalNumberOfResults() == ids.size());
+        assertTrue("browse items result id exists", response.getResultId() != null);
+        assertNotNull("browse facet [Brand] exists", brandFacet);
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -1,9 +1,11 @@
 package io.constructor.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.function.Predicate;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,6 +13,7 @@ import org.junit.rules.ExpectedException;
 
 import io.constructor.client.models.BrowseResponse;
 import io.constructor.client.models.FilterGroup;
+import io.constructor.client.models.FilterFacet;
 
 public class ConstructorIOBrowseTest {
 
@@ -196,5 +199,23 @@ public class ConstructorIOBrowseTest {
         BrowseResponse response = constructor.browse(request, userInfo);
         assertEquals("browse results exist", response.getResponse().getResults().size(), 1);
         assertEquals("browse result [testField] exists", response.getResponse().getResults().get(0).getData().getMetadata().get("testField"), "hiddenFieldValue");
+    }
+
+    @Test
+    public void BrowseShouldReturnAResultWithHiddenFacets() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        BrowseRequest request = new BrowseRequest("Brand", "XYZ");
+        request.getHiddenFacets().add("Brand");
+        BrowseResponse response = constructor.browse(request, userInfo);
+        FilterFacet brandFacet = response.getResponse().getFacets().stream().filter(new Predicate<FilterFacet>() {
+            @Override
+            public boolean test(FilterFacet f) {
+                return f.getName().equals("Brand");
+            }
+        }).findAny().orElse(null);
+
+        assertEquals("browse results exist", response.getResponse().getResults().size(), 1);
+        assertNotNull("browse facet [Brand] exists", brandFacet);
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -1,15 +1,18 @@
 package io.constructor.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
+import java.util.function.Predicate;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import io.constructor.client.models.FilterFacet;
 import io.constructor.client.models.FilterGroup;
 import io.constructor.client.models.SearchResponse;
 
@@ -199,6 +202,26 @@ public class ConstructorIOSearchTest {
         SearchResponse response = constructor.search(request, userInfo);
         assertEquals("search results exist", response.getResponse().getResults().size(), 9);
         assertEquals("search result [testField] exists", response.getResponse().getResults().get(0).getData().getMetadata().get("testField"), "hiddenFieldValue");
+    }
+
+    @Test
+    public void SearchShouldReturnAResultWithHiddenFacets() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        SearchRequest request = new SearchRequest("item1");
+        request.getHiddenFacets().add("Brand");
+
+        System.out.println(request.getHiddenFacets());
+        SearchResponse response = constructor.search(request, userInfo);
+        FilterFacet brandFacet = response.getResponse().getFacets().stream().filter(new Predicate<FilterFacet>() {
+            @Override
+            public boolean test(FilterFacet f) {
+                return f.getName().equals("Brand");
+            }
+        }).findAny().orElse(null);
+
+        assertEquals("search results exist", response.getResponse().getResults().size(), 9);
+        assertNotNull("search facet [Brand] exists", brandFacet);
     }
 
     @Test

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -211,7 +211,6 @@ public class ConstructorIOSearchTest {
         SearchRequest request = new SearchRequest("item1");
         request.getHiddenFacets().add("Brand");
 
-        System.out.println(request.getHiddenFacets());
         SearchResponse response = constructor.search(request, userInfo);
         FilterFacet brandFacet = response.getResponse().getFacets().stream().filter(new Predicate<FilterFacet>() {
             @Override

--- a/constructorio-client/src/test/java/io/constructor/client/SearchRequestTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/SearchRequestTest.java
@@ -55,6 +55,7 @@ public class SearchRequestTest {
         Map<String, String> formatOptions = new HashMap<String, String>();
         formatOptions.put("groups_start", "top");
         List<String> hiddenFields = Arrays.asList("hiddenField1", "hiddenField2");
+        List<String> hiddenFacets = Arrays.asList("hiddenFacet1", "hiddenFacet2");
         
         request.setQuery("airline tickets");
         request.setSection("Search Suggestions");
@@ -67,6 +68,7 @@ public class SearchRequestTest {
         request.setCollectionId("last minute getaways");
         request.setFormatOptions(formatOptions);
         request.setHiddenFields(hiddenFields);
+        request.setHiddenFacets(hiddenFacets);
         
         assertEquals(request.getQuery(), "airline tickets");
         assertEquals(request.getSection(), "Search Suggestions");
@@ -79,5 +81,6 @@ public class SearchRequestTest {
         assertEquals(request.getCollectionId(), "last minute getaways");
         assertEquals(request.getFormatOptions(), formatOptions);
         assertEquals(request.getHiddenFields(), hiddenFields);
+        assertEquals(request.getHiddenFacets(), hiddenFacets);
     }
 }


### PR DESCRIPTION
### Updates:
* Add support for hidden facets to Search,Browse, and Browse Items endpoints
* Switch hidden fields query params to use format options

### Notes:
* Autocomplete doesn't seem to support format options so no changes were made there