### PR TITLE
[CSL-1002] Add support for browse facets/options

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/BrowseFacetOptionsRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/BrowseFacetOptionsRequest.java
@@ -1,0 +1,52 @@
+package io.constructor.client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Constructor.io Browse Facet options Request
+ */
+public class BrowseFacetOptionsRequest {
+
+    private String facetName;
+    private Map<String, String>formatOptions;
+
+    /**
+     * Creates a browse facet options request
+     *
+     */
+    public BrowseFacetOptionsRequest(String facetName) throws IllegalArgumentException {
+        this.facetName = facetName;
+        this.formatOptions = new HashMap<String, String>();
+    }
+
+    /**
+     * @return the facetName
+     */
+    public String getFacetName() {
+        return facetName;
+    }
+
+    /**
+     * @param facetName the facetName to set
+     */
+    public void setFacetName(String facetName) {
+        this.facetName = facetName;
+    }
+
+    /**
+     * @param formatOptions the formatOptions to set
+     */
+    public void setFormatOptions(Map<String, String> formatOptions) {
+        this.formatOptions = formatOptions;
+    }
+
+    /**
+     * @return the format options
+     */
+    public Map<String, String> getFormatOptions() {
+        return formatOptions;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/BrowseFacetsRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/BrowseFacetsRequest.java
@@ -1,0 +1,67 @@
+package io.constructor.client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Constructor.io Browse Facets Request
+ */
+public class BrowseFacetsRequest {
+
+    private int page;
+    private int resultsPerPage;
+    private Map<String, String>formatOptions;
+    /**
+     * Creates a browse facets request
+     *
+     */
+    public BrowseFacetsRequest() throws IllegalArgumentException {
+        this.page = 1;
+        this.resultsPerPage = 20;
+        this.formatOptions = new HashMap<String, String>();
+    }
+
+    /**
+     * @return the page
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     * @param page the page to set
+     */
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    /**
+     * @return the resultsPerPage
+     */
+    public int getResultsPerPage() {
+        return resultsPerPage;
+    }
+
+    /**
+     * @param resultsPerPage the resultsPerPage to set
+     */
+    public void setResultsPerPage(int resultsPerPage) {
+        this.resultsPerPage = resultsPerPage;
+    }
+
+    /**
+     * @param formatOptions the formatOptions to set
+     */
+    public void setFormatOptions(Map<String, String> formatOptions) {
+        this.formatOptions = formatOptions;
+    }
+
+    /**
+     * @return the format options
+     */
+    public Map<String, String> getFormatOptions() {
+        return formatOptions;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/BrowseFacetsRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/BrowseFacetsRequest.java
@@ -13,6 +13,7 @@ public class BrowseFacetsRequest {
     private int page;
     private int resultsPerPage;
     private Map<String, String>formatOptions;
+
     /**
      * Creates a browse facets request
      *

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -13,17 +13,11 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.gson.Gson;
 
+import io.constructor.client.models.*;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import io.constructor.client.models.AutocompleteResponse;
-import io.constructor.client.models.BrowseResponse;
-import io.constructor.client.models.SearchResponse;
-import io.constructor.client.models.RecommendationsResponse;
-import io.constructor.client.models.ServerError;
-import io.constructor.client.models.AllTasksResponse;
-import io.constructor.client.models.Task;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.HttpUrl;
@@ -558,6 +552,8 @@ public class ConstructorIO {
                 .get()
                 .build();
 
+
+            System.out.println(url);
             return request;
         } catch (Exception exception) {
             throw new ConstructorException(exception);
@@ -946,6 +942,148 @@ public class ConstructorIO {
     }
 
     /**
+     * Creates a browse facets OkHttp request
+     *
+     * @param req the browse facets request
+     * @return a browse OkHttp request
+     * @throws ConstructorException
+     */
+    protected Request createBrowseFacetsRequest(BrowseFacetsRequest req) throws ConstructorException {
+        try {
+            List<String> paths = Arrays.asList("browse", "facets");
+            HttpUrl url = this.makeUrl(paths);
+            url = url.newBuilder()
+                    .addQueryParameter("page", String.valueOf(req.getPage()))
+                    .addQueryParameter("num_results_per_page", String.valueOf(req.getResultsPerPage()))
+                    .build();
+
+            for (String formatOptionKey : req.getFormatOptions().keySet()) {
+                String formatOptionValue = req.getFormatOptions().get(formatOptionKey);
+                url = url.newBuilder()
+                        .addQueryParameter("fmt_options[" + formatOptionKey + "]", formatOptionValue)
+                        .build();
+            }
+
+            Request request = this.makeAuthorizedRequestBuilder()
+                    .url(url)
+                    .get()
+                    .build();
+
+            return request;
+        } catch (Exception exception) {
+            throw new ConstructorException(exception);
+        }
+    }
+
+    /**
+     * Queries the browse facets service
+     *
+     *
+     * @param req the browse facets request
+     * @return a browse facets response
+     * @throws ConstructorException if the request is invalid.
+     */
+    public BrowseFacetsResponse browseFacets(BrowseFacetsRequest req) throws ConstructorException {
+        try {
+            Request request = createBrowseFacetsRequest(req);
+            Response response = clientWithRetry.newCall(request).execute();
+            String json = getResponseBody(response);
+            return createBrowseFacetsResponse(json);
+        } catch (Exception exception) {
+            throw new ConstructorException(exception);
+        }
+    }
+
+    /**
+     * Queries the browse facets service
+     *
+     *
+     * @param req the browse facets request
+     * @return a string of JSON
+     * @throws ConstructorException if the request is invalid.
+     */
+    public String browseFacetsAsJSON(BrowseFacetsRequest req) throws ConstructorException {
+        try {
+            Request request = createBrowseFacetsRequest(req);
+            Response response = clientWithRetry.newCall(request).execute();
+            return getResponseBody(response);
+        } catch (Exception exception) {
+            throw new ConstructorException(exception);
+        }
+    }
+
+    /**
+     * Creates a browse facets OkHttp request
+     *
+     * @param req the browse facets request
+     * @return a browse OkHttp request
+     * @throws ConstructorException
+     */
+    protected Request createBrowseFacetOptionsRequest (BrowseFacetOptionsRequest req) throws ConstructorException {
+        try {
+            List<String> paths = Arrays.asList("browse", "facet_options");
+            HttpUrl url = this.makeUrl(paths);
+            url = url.newBuilder()
+                    .addQueryParameter("facet_name", String.valueOf(req.getFacetName()))
+                    .build();
+
+            for (String formatOptionKey : req.getFormatOptions().keySet()) {
+                String formatOptionValue = req.getFormatOptions().get(formatOptionKey);
+                url = url.newBuilder()
+                        .addQueryParameter("fmt_options[" + formatOptionKey + "]", formatOptionValue)
+                        .build();
+            }
+
+            Request request = this.makeAuthorizedRequestBuilder()
+                    .url(url)
+                    .get()
+                    .build();
+
+            System.out.println(url);
+            return request;
+        } catch (Exception exception) {
+            throw new ConstructorException(exception);
+        }
+    }
+
+    /**
+     * Queries the browse facet options service
+     *
+     *
+     * @param req the browse facet options request
+     * @return a browse facet options response
+     * @throws ConstructorException if the request is invalid.
+     */
+    public BrowseFacetOptionsResponse browseFacetOptions(BrowseFacetOptionsRequest req) throws ConstructorException {
+        try {
+            Request request = createBrowseFacetOptionsRequest(req);
+            Response response = clientWithRetry.newCall(request).execute();
+            String json = getResponseBody(response);
+            return createBrowseFacetOptionsResponse(json);
+        } catch (Exception exception) {
+            throw new ConstructorException(exception);
+        }
+    }
+
+    /**
+     * Queries the browse facet options service
+     *
+     *
+     * @param req the browse facet options request
+     * @return a string of JSON
+     * @throws ConstructorException if the request is invalid.
+     */
+    public String browseFacetOptionsAsJSON(BrowseFacetOptionsRequest req) throws ConstructorException {
+        try {
+            Request request = createBrowseFacetOptionsRequest(req);
+            Response response = clientWithRetry.newCall(request).execute();
+            return getResponseBody(response);
+        } catch (Exception exception) {
+            throw new ConstructorException(exception);
+        }
+    }
+
+    /**
      * Queries the search service with natural language processing.
      *
      * Note that if you're making a search request for a website, you should definitely use our javascript client instead of doing it server-side!
@@ -1241,6 +1379,28 @@ public class ConstructorIO {
       String transformed = json.toString();
       return new Gson().fromJson(transformed, BrowseResponse.class);
   }
+
+    /**
+     * Transforms a JSON string to a new JSON string for easy Gson parsing into an browse facets response.
+     * Using JSON objects to acheive this is considerably less error prone than attempting to do it in
+     * a Gson Type Adapter.
+     */
+    protected static BrowseFacetsResponse createBrowseFacetsResponse(String string) {
+        JSONObject json = new JSONObject(string);
+        String transformed = json.toString();
+        return new Gson().fromJson(transformed, BrowseFacetsResponse.class);
+    }
+
+    /**
+     * Transforms a JSON string to a new JSON string for easy Gson parsing into an browse facets response.
+     * Using JSON objects to acheive this is considerably less error prone than attempting to do it in
+     * a Gson Type Adapter.
+     */
+    protected static BrowseFacetOptionsResponse createBrowseFacetOptionsResponse(String string) {
+        JSONObject json = new JSONObject(string);
+        String transformed = json.toString();
+        return new Gson().fromJson(transformed, BrowseFacetOptionsResponse.class);
+    }
 
     /**
      * Transforms a JSON string to a new JSON string for easy Gson parsing into an recommendations response.

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -13,11 +13,19 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.gson.Gson;
 
-import io.constructor.client.models.*;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import io.constructor.client.models.AutocompleteResponse;
+import io.constructor.client.models.BrowseResponse;
+import io.constructor.client.models.SearchResponse;
+import io.constructor.client.models.RecommendationsResponse;
+import io.constructor.client.models.ServerError;
+import io.constructor.client.models.AllTasksResponse;
+import io.constructor.client.models.Task;
+import io.constructor.client.models.BrowseFacetOptionsResponse;
+import io.constructor.client.models.BrowseFacetsResponse;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.HttpUrl;
@@ -552,8 +560,6 @@ public class ConstructorIO {
                 .get()
                 .build();
 
-
-            System.out.println(url);
             return request;
         } catch (Exception exception) {
             throw new ConstructorException(exception);
@@ -1039,7 +1045,6 @@ public class ConstructorIO {
                     .get()
                     .build();
 
-            System.out.println(url);
             return request;
         } catch (Exception exception) {
             throw new ConstructorException(exception);

--- a/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetOptionsResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetOptionsResponse.java
@@ -1,0 +1,41 @@
+package io.constructor.client.models;
+
+import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Constructor.io Browse Facet Options Response ... uses Gson/Reflection to load data in
+ */
+public class BrowseFacetOptionsResponse {
+
+    @SerializedName("result_id")
+    private String resultId;
+
+    @SerializedName("response")
+    private BrowseFacetOptionsResponseInner response;
+
+    @SerializedName("request")
+    private Map<String, Object> request;
+
+    /**
+     * @return the resultId
+     */
+    public String getResultId() {
+        return resultId;
+    }
+
+    /**
+     * @return the response
+     */
+    public BrowseFacetOptionsResponseInner getResponse() {
+        return response;
+    }
+
+    /**
+     * @return the request as understood by the server
+     */
+    public Map<String, Object> getRequest() {
+        return request;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetOptionsResponseInner.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetOptionsResponseInner.java
@@ -1,0 +1,21 @@
+package io.constructor.client.models;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Constructor.io Browse Facet Options Response Inner ... uses Gson/Reflection to load data in
+ */
+public class BrowseFacetOptionsResponseInner {
+
+    @SerializedName("facets")
+    List<FilterFacet> facets;
+
+    /**
+     * @return the facets
+     */
+    public List<FilterFacet> getFacets() {
+        return facets;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetsResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetsResponse.java
@@ -8,6 +8,7 @@ import com.google.gson.annotations.SerializedName;
  * Constructor.io Browse Facet Response ... uses Gson/Reflection to load data in
  */
 public class BrowseFacetsResponse {
+
     @SerializedName("result_id")
     private String resultId;
 

--- a/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetsResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetsResponse.java
@@ -1,0 +1,40 @@
+package io.constructor.client.models;
+
+import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Constructor.io Browse Facet Response ... uses Gson/Reflection to load data in
+ */
+public class BrowseFacetsResponse {
+    @SerializedName("result_id")
+    private String resultId;
+
+    @SerializedName("response")
+    private BrowseFacetsResponseInner response;
+
+    @SerializedName("request")
+    private Map<String, Object> request;
+
+    /**
+     * @return the resultId
+     */
+    public String getResultId() {
+        return resultId;
+    }
+
+    /**
+     * @return the response
+     */
+    public BrowseFacetsResponseInner getResponse() {
+        return response;
+    }
+
+    /**
+     * @return the request as understood by the server
+     */
+    public Map<String, Object> getRequest() {
+        return request;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetsResponseInner.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/BrowseFacetsResponseInner.java
@@ -1,0 +1,32 @@
+package io.constructor.client.models;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Constructor.io Browse Facet Response Inner ... uses Gson/Reflection to load data in
+ */
+public class BrowseFacetsResponseInner {
+
+    @SerializedName("facets")
+    List<FilterFacet> facets;
+
+    @SerializedName("total_num_results")
+    private Integer totalNumberOfResults;
+
+    /**
+     * @return the facets
+     */
+    public List<FilterFacet> getFacets() {
+        return facets;
+    }
+
+    /**
+     * @return the totalNumberOfResults
+     */
+    public Integer getTotalNumberOfResults() {
+        return totalNumberOfResults;
+    }
+
+}

--- a/constructorio-client/src/test/java/io/constructor/client/BrowseFacetOptionsRequestTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/BrowseFacetOptionsRequestTest.java
@@ -1,0 +1,33 @@
+package io.constructor.client;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class BrowseFacetOptionsRequestTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void newShouldReturnBrowseFacetOptionsRequestWithDefaults() throws Exception {
+        BrowseFacetOptionsRequest request = new BrowseFacetOptionsRequest("Color");
+        assertEquals(0, request.getFormatOptions().size());
+        assertEquals("Color", request.getFacetName());
+    }
+
+    @Test
+    public void settersShouldSet() throws Exception {
+        BrowseFacetOptionsRequest request = new BrowseFacetOptionsRequest("Color");
+        assertEquals(0, request.getFormatOptions().size());
+        assertEquals("Color", request.getFacetName());
+
+        request.setFacetName("Brand");
+        request.getFormatOptions().put("show_hidden_facets", "True");
+
+        assertEquals(1, request.getFormatOptions().size());
+        assertEquals("Brand", request.getFacetName());
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/BrowseFacetOptionsResponseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/BrowseFacetOptionsResponseTest.java
@@ -1,0 +1,28 @@
+package io.constructor.client;
+
+import io.constructor.client.models.BrowseFacetOptionsResponse;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+
+public class BrowseFacetOptionsResponseTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void createBrowseFacetOptionsResponseShouldReturnAResult() throws Exception {
+        String string = Utils.getTestResource("response.browsefacetoptions.json");
+        BrowseFacetOptionsResponse response = ConstructorIO.createBrowseFacetOptionsResponse(string);
+
+        assertEquals("1 facet exists", 1, response.getResponse().getFacets().size());
+        assertEquals("result_id exists", "b776803b-5e00-4c92-b519-3ef58bf027f6", response.getResultId());
+        assertEquals("display_name exists", "Color", response.getResponse().getFacets().get(0).getDisplayName());
+        assertEquals("name exists", "Color", response.getResponse().getFacets().get(0).getName());
+        assertEquals("type exists", "multiple", response.getResponse().getFacets().get(0).getType());
+        assertEquals("4 options exists", 4, response.getResponse().getFacets().get(0).getOptions().size());
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/BrowseFacetsRequestTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/BrowseFacetsRequestTest.java
@@ -1,0 +1,39 @@
+package io.constructor.client;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class BrowseFacetsRequestTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void newShouldReturnBrowseFacetsRequestWithDefaults() throws Exception {
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+
+        assertEquals(0, request.getFormatOptions().size());
+        assertEquals(1, request.getPage());
+        assertEquals(20, request.getResultsPerPage());
+    }
+
+    @Test
+    public void settersShouldSet() throws Exception {
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+
+        assertEquals(0, request.getFormatOptions().size());
+        assertEquals(1, request.getPage());
+        assertEquals(20, request.getResultsPerPage());
+
+        request.setPage(2);
+        request.setResultsPerPage(50);
+        request.getFormatOptions().put("show_hidden_facets", "True");
+
+        assertEquals(1, request.getFormatOptions().size());
+        assertEquals(2, request.getPage());
+        assertEquals(50, request.getResultsPerPage());
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/BrowseFacetsResponseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/BrowseFacetsResponseTest.java
@@ -1,0 +1,29 @@
+package io.constructor.client;
+
+import io.constructor.client.models.BrowseFacetOptionsResponse;
+import io.constructor.client.models.BrowseFacetsResponse;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+
+public class BrowseFacetsResponseTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void createBrowseFacetOptionsResponseShouldReturnAResult() throws Exception {
+        String string = Utils.getTestResource("response.browsefacets.json");
+        BrowseFacetsResponse response = ConstructorIO.createBrowseFacetsResponse(string);
+
+        assertTrue("total_num_results exists",  response.getResponse().getTotalNumberOfResults() == 15);
+        assertEquals("result_id exists", "d3fe21ab-41eb-4f57-9e24-92cfaf5c89f1", response.getResultId());
+        assertEquals("15 facets exist", 15, response.getResponse().getFacets().size());
+        assertEquals("display_name exists", "articleNumberManufacturer", response.getResponse().getFacets().get(0).getDisplayName());
+        assertEquals("name exists", "articleNumberManufacturer", response.getResponse().getFacets().get(0).getName());
+        assertEquals("type exists", "multiple", response.getResponse().getFacets().get(0).getType());
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseFacetOptionsTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseFacetOptionsTest.java
@@ -1,0 +1,64 @@
+package io.constructor.client;
+
+import static org.junit.Assert.assertTrue;
+
+import io.constructor.client.models.BrowseFacetOptionsResponse;
+import org.json.JSONObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ConstructorIOBrowseFacetOptionsTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    private String apiKey = System.getenv("TEST_API_KEY");
+    private String apiToken = System.getenv("TEST_API_TOKEN");
+    private String facetName = "Color";
+
+    @Test
+    public void BrowseFacetOptionsShouldReturnAResult() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        BrowseFacetOptionsRequest request = new BrowseFacetOptionsRequest(facetName);
+        BrowseFacetOptionsResponse response = constructor.browseFacetOptions(request);
+
+        assertTrue("browse facets results exist", response.getResponse().getFacets().size() > 0);
+        assertTrue("browse facets result id exists", response.getResultId() != null);
+    }
+
+    @Test
+    public void BrowseFacetOptionsAsJSONShouldReturnAResult() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        BrowseFacetOptionsRequest request = new BrowseFacetOptionsRequest(facetName);
+        String response = constructor.browseFacetOptionsAsJSON(request);
+
+        assertTrue("browse facets results exist", response.length() > 0);
+    }
+
+    @Test
+    public void BrowseFacetOptionsShouldReturnAResultWithValidFmtOptions() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        BrowseFacetOptionsRequest request = new BrowseFacetOptionsRequest(facetName);
+        request.getFormatOptions().put("show_hidden_facets", "True");
+        request.getFormatOptions().put("show_protected_facets", "True");
+        BrowseFacetOptionsResponse response = constructor.browseFacetOptions(request);
+
+        assertTrue("browse facets results exist", response.getResponse().getFacets().size() > 0);
+        assertTrue("browse facets result id exists", response.getResultId() != null);
+    }
+
+
+    @Test
+    public void BrowseFacetOptionsAsJSONShouldReturnAResultWithValidFmtOptions() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        BrowseFacetOptionsRequest request = new BrowseFacetOptionsRequest(facetName);
+        request.getFormatOptions().put("show_hidden_facets", "True");
+        request.getFormatOptions().put("show_protected_facets", "True");
+        String response = constructor.browseFacetOptionsAsJSON(request);
+        JSONObject jsonObj = new JSONObject(response);
+
+        assertTrue("browse facets results exist", response.length() > 0);
+        assertTrue("show_hidden_facets is set in request", jsonObj.getJSONObject("request").getJSONObject("fmt_options").getBoolean("show_hidden_facets"));
+        assertTrue("show_hidden_facets is set in request", jsonObj.getJSONObject("request").getJSONObject("fmt_options").getBoolean("show_protected_facets"));
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseFacetsTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseFacetsTest.java
@@ -1,0 +1,126 @@
+package io.constructor.client;
+
+import static org.junit.Assert.assertTrue;
+
+import io.constructor.client.models.BrowseFacetsResponse;
+import org.json.JSONObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ConstructorIOBrowseFacetsTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    private String apiKey = System.getenv("TEST_API_KEY");
+    private String apiToken = System.getenv("TEST_API_TOKEN");
+
+    @Test
+    public void BrowseFacetsShouldReturnAResult() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+        BrowseFacetsResponse response = constructor.browseFacets(request);
+
+        assertTrue("browse facets results exist", response.getResponse().getFacets().size() > 0);
+        assertTrue("browse facets result id exists", response.getResultId() != null);
+    }
+
+    @Test
+    public void BrowseFacetsAsJSONShouldReturnAResult() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+        String response = constructor.browseFacetsAsJSON(request);
+
+        assertTrue("browse facets results exist", response.length() > 0);
+    }
+
+    @Test
+    public void BrowseFacetsShouldReturnAResultWithValidFmtOptions() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+        request.getFormatOptions().put("show_hidden_facets", "True");
+        request.getFormatOptions().put("show_protected_facets", "True");
+        BrowseFacetsResponse response = constructor.browseFacets(request);
+
+        assertTrue("browse facets results exist", response.getResponse().getFacets().size() > 0);
+        assertTrue("browse facets total_num_results exist", response.getResponse().getTotalNumberOfResults() > 0);
+        assertTrue("browse facets result id exists", response.getResultId() != null);
+    }
+
+
+    @Test
+    public void BrowseFacetsAsJSONShouldReturnAResultWithValidFmtOptions() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+        request.getFormatOptions().put("show_hidden_facets", "True");
+        request.getFormatOptions().put("show_protected_facets", "True");
+        String response = constructor.browseFacetsAsJSON(request);
+        JSONObject jsonObj = new JSONObject(response);
+
+        assertTrue("browse facets results exist", response.length() > 0);
+        assertTrue("show_hidden_facets is set in request", jsonObj.getJSONObject("request").getJSONObject("fmt_options").getBoolean("show_hidden_facets"));
+        assertTrue("show_hidden_facets is set in request", jsonObj.getJSONObject("request").getJSONObject("fmt_options").getBoolean("show_protected_facets"));
+    }
+
+    @Test
+    public void BrowseFacetsShouldReturnAResultWithFivePerPage() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+        request.setResultsPerPage(5);
+        request.getFormatOptions().put("show_hidden_facets", "True");
+        request.getFormatOptions().put("show_protected_facets", "True");
+        BrowseFacetsResponse response = constructor.browseFacets(request);
+
+        assertTrue("browse facets results exist", response.getResponse().getFacets().size() > 0);
+        assertTrue("browse facets total_num_results exist", response.getResponse().getTotalNumberOfResults() > 0);
+        assertTrue("browse facets result id exists", response.getResultId() != null);
+    }
+
+
+    @Test
+    public void BrowseFacetsAsJSONShouldReturnAResultWithFivePerPage() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+        request.setResultsPerPage(5);
+        request.getFormatOptions().put("show_hidden_facets", "True");
+        request.getFormatOptions().put("show_protected_facets", "True");
+        String response = constructor.browseFacetsAsJSON(request);
+        JSONObject jsonObj = new JSONObject(response);
+
+        assertTrue("browse facets results exist", response.length() > 0);
+        assertTrue("num_results_per_page is set in request", jsonObj.getJSONObject("request").getInt("num_results_per_page") == 5);
+        assertTrue("show_hidden_facets is set in request", jsonObj.getJSONObject("request").getJSONObject("fmt_options").getBoolean("show_hidden_facets"));
+        assertTrue("show_hidden_facets is set in request", jsonObj.getJSONObject("request").getJSONObject("fmt_options").getBoolean("show_protected_facets"));
+    }
+
+    @Test
+    public void BrowseFacetsShouldReturnAResultWithThirdPage() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+        request.setPage(3);
+        request.getFormatOptions().put("show_hidden_facets", "True");
+        request.getFormatOptions().put("show_protected_facets", "True");
+        BrowseFacetsResponse response = constructor.browseFacets(request);
+
+        assertTrue("browse facets results exist", response.getResponse().getFacets().size() >= 0);
+        assertTrue("browse facets total_num_results exist", response.getResponse().getTotalNumberOfResults() > 0);
+        assertTrue("browse facets result id exists", response.getResultId() != null);
+    }
+
+
+    @Test
+    public void BrowseFacetsAsJSONShouldReturnAResultWithThirdPage() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null);
+        BrowseFacetsRequest request = new BrowseFacetsRequest();
+        request.setPage(3);
+        request.getFormatOptions().put("show_hidden_facets", "True");
+        request.getFormatOptions().put("show_protected_facets", "True");
+        String response = constructor.browseFacetsAsJSON(request);
+        JSONObject jsonObj = new JSONObject(response);
+
+        assertTrue("browse facets results exist", response.length() > 0);
+        assertTrue("num_results_per_page is set in request", jsonObj.getJSONObject("request").getInt("page") == 3);
+        assertTrue("show_hidden_facets is set in request", jsonObj.getJSONObject("request").getJSONObject("fmt_options").getBoolean("show_hidden_facets"));
+        assertTrue("show_hidden_facets is set in request", jsonObj.getJSONObject("request").getJSONObject("fmt_options").getBoolean("show_protected_facets"));
+    }
+}

--- a/constructorio-client/src/test/resources/response.browsefacetoptions.json
+++ b/constructorio-client/src/test/resources/response.browsefacetoptions.json
@@ -1,0 +1,70 @@
+{
+  "response": {
+    "facets": [
+      {
+        "display_name": "Color",
+        "name": "Color",
+        "type": "multiple",
+        "options": [
+          {
+            "status": "",
+            "count": 2,
+            "display_name": "Blue",
+            "value": "Blue",
+            "data": {}
+          },
+          {
+            "status": "",
+            "count": 1,
+            "display_name": "yellow",
+            "value": "yellow",
+            "data": {}
+          },
+          {
+            "status": "",
+            "count": 1,
+            "display_name": "red",
+            "value": "red",
+            "data": {}
+          },
+          {
+            "status": "",
+            "count": 1,
+            "display_name": "green",
+            "value": "green",
+            "data": {}
+          }
+        ],
+        "data": {}
+      }
+    ]
+  },
+  "result_id": "b776803b-5e00-4c92-b519-3ef58bf027f6",
+  "request": {
+    "facet_name": "Color",
+    "term": "",
+    "page": 1,
+    "num_results_per_page": 20,
+    "fmt_options": {
+      "groups_start": "current",
+      "groups_max_depth": 1
+    },
+    "sort_by": "relevance",
+    "sort_order": "descending",
+    "section": "Products",
+    "features": {
+      "query_items": true,
+      "auto_generated_refined_query_rules": true,
+      "manual_searchandizing": true,
+      "personalization": true,
+      "filter_items": true
+    },
+    "feature_variants": {
+      "query_items": null,
+      "auto_generated_refined_query_rules": null,
+      "manual_searchandizing": null,
+      "personalization": null,
+      "filter_items": null
+    }
+  }
+}

--- a/constructorio-client/src/test/resources/response.browsefacets.json
+++ b/constructorio-client/src/test/resources/response.browsefacets.json
@@ -1,0 +1,124 @@
+{
+  "response": {
+    "facets": [
+      {
+        "display_name": "articleNumberManufacturer",
+        "name": "articleNumberManufacturer",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "articleNumberMax",
+        "name": "articleNumberMax",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "baseId",
+        "name": "baseId",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "Color",
+        "name": "Color",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "color",
+        "name": "color",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "colorFreeDefinition",
+        "name": "colorFreeDefinition",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "commonSize",
+        "name": "commonSize",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "designer",
+        "name": "designer",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "flavor",
+        "name": "flavor",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "gender",
+        "name": "gender",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "madeInItaly",
+        "name": "madeInItaly",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "matrixId",
+        "name": "matrixId",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "season",
+        "name": "season",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "size",
+        "name": "size",
+        "type": "multiple",
+        "data": {}
+      },
+      {
+        "display_name": "style",
+        "name": "style",
+        "type": "multiple",
+        "data": {}
+      }
+    ],
+    "total_num_results": 15
+  },
+  "result_id": "d3fe21ab-41eb-4f57-9e24-92cfaf5c89f1",
+  "request": {
+    "page": 1,
+    "num_results_per_page": 20,
+    "term": "",
+    "fmt_options": {
+      "groups_start": "current",
+      "groups_max_depth": 1
+    },
+    "sort_by": "relevance",
+    "sort_order": "descending",
+    "section": "Products",
+    "features": {
+      "query_items": true,
+      "auto_generated_refined_query_rules": true,
+      "manual_searchandizing": true,
+      "personalization": true,
+      "filter_items": true
+    },
+    "feature_variants": {
+      "query_items": null,
+      "auto_generated_refined_query_rules": null,
+      "manual_searchandizing": null,
+      "personalization": null,
+      "filter_items": null
+    }
+  }
+}


### PR DESCRIPTION
I added browse facets as well since I don't think it was there before.

Some search tests fail but that issue is on the backend

https://linear.app/constructor/issue/CSL-1134/java-client-fix-failing-tests
https://constructor.slack.com/archives/CB8KY6538/p1648509178318189