### PR TITLE
[CSL-1402] Variations Map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ request.setResultsPerSection(resultsPerSection);
 UserInfo userInfo = new UserInfo(5, "device-id-1123123");
 userInfo.setUserSegments(Arrays.asList("Desktop", "Chrome"));
 
+// Add a variations map to request specific variation attributes as an array or object (optional)
+VariationsMap variationsMap = new VariationsMap();
+variationsMap.setdType(VariationsMap.Dtypes.array);
+variationsMap.addGroupByRule("variation", "data.variation_id");
+variationsMap.addValueRule("size", VariationsMap.AggregationTypes.first, "data.facets.size");
+request.setVariationsMap(variationsMap);
+
 // Request results as an object
 AutocompleteResponse response = constructor.autocomplete(request, userInfo);
 
@@ -135,6 +142,13 @@ request.getHiddenFacets().add("hidden_brand_facet");
 // Create a UserInfo object with the session and unique device identifier (optional)
 UserInfo userInfo = new UserInfo(5, "device-id-1123123");
 userInfo.setUserSegments(Arrays.asList("Desktop", "Chrome"));
+
+// Add a variations map to request specific variation attributes as an array or object (optional)
+VariationsMap variationsMap = new VariationsMap();
+variationsMap.setdType(VariationsMap.Dtypes.array);
+variationsMap.addGroupByRule("variation", "data.variation_id");
+variationsMap.addValueRule("size", VariationsMap.AggregationTypes.first, "data.facets.size");
+request.setVariationsMap(variationsMap);
 
 // Request results as an object
 SearchResponse response = constructor.search(request, userInfo);
@@ -216,6 +230,13 @@ request.getHiddenFacets().add("hidden_brand_facet");
 // Create a UserInfo object with the session and unique device identifier (optional)
 UserInfo userInfo = new UserInfo(5, "device-id-1123123");
 userInfo.setUserSegments(Arrays.asList("Desktop", "Chrome"));
+
+// Add a variations map to request specific variation attributes as an array or object (optional)
+VariationsMap variationsMap = new VariationsMap();
+variationsMap.setdType(VariationsMap.Dtypes.array);
+variationsMap.addGroupByRule("variation", "data.variation_id");
+variationsMap.addValueRule("size", VariationsMap.AggregationTypes.first, "data.facets.size");
+request.setVariationsMap(variationsMap);
 
 // Request results as an object
 BrowseResponse response = constructor.browse(request, userInfo);
@@ -302,6 +323,13 @@ request.setItemIds(Arrays.asList("9838172"))
 // Create a UserInfo object with the session and unique device identifier (optional)
 UserInfo userInfo = new UserInfo(5, "device-id-1123123");
 userInfo.setUserSegments(Arrays.asList("Desktop", "Chrome"));
+
+// Add a variations map to request specific variation attributes as an array or object (optional)
+VariationsMap variationsMap = new VariationsMap();
+variationsMap.setdType(VariationsMap.Dtypes.array);
+variationsMap.addGroupByRule("variation", "data.variation_id");
+variationsMap.addValueRule("size", VariationsMap.AggregationTypes.first, "data.facets.size");
+request.setVariationsMap(variationsMap);
 
 // Request results as an object
 RecommendationsResponse response = constructor.recommendations(request, userInfo);

--- a/constructorio-client/src/main/java/io/constructor/client/AutocompleteRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/AutocompleteRequest.java
@@ -14,6 +14,7 @@ public class AutocompleteRequest {
     private Map<String, Integer> resultsPerSection;
     private List<String> hiddenFields;
     private Map<String, List<String>> filters;
+    private VariationsMap variationsMap;
 
     /**
      * Creates an autocomplete request
@@ -29,6 +30,7 @@ public class AutocompleteRequest {
       this.resultsPerSection = new HashMap<String, Integer>();
       this.hiddenFields = new ArrayList<String>();
       this.filters = new HashMap<String, List<String>>();
+      this.variationsMap = null;
     }
 
     /**
@@ -85,5 +87,19 @@ public class AutocompleteRequest {
      */
     public Map<String, List<String>> getFilters() {
       return filters;
+    }
+
+    /**
+     * @param variationsMap the variationsMap to set
+     */
+    public void setVariationsMap(VariationsMap variationsMap) {
+        this.variationsMap = variationsMap;
+    }
+
+    /**
+     * @return the variations map
+     */
+    public VariationsMap getVariationsMap() {
+        return variationsMap;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/BrowseRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/BrowseRequest.java
@@ -22,6 +22,7 @@ public class BrowseRequest {
     private Map<String, String>formatOptions;
     private List<String> hiddenFields;
     private List<String> hiddenFacets;
+    private VariationsMap variationsMap;
     
     /**
      * Creates a browse request
@@ -47,6 +48,7 @@ public class BrowseRequest {
       this.formatOptions = new HashMap<String, String>();
       this.hiddenFields = new ArrayList<String>();
       this.hiddenFacets = new ArrayList<String>();
+      this.variationsMap = null;
     }
 
     /**
@@ -215,5 +217,19 @@ public class BrowseRequest {
      */
     public List<String> getHiddenFacets() {
       return hiddenFacets;
+    }
+
+    /**
+     * @param variationsMap the variationsMap to set
+     */
+    public void setVariationsMap(VariationsMap variationsMap) {
+        this.variationsMap = variationsMap;
+    }
+
+    /**
+     * @return the variations map
+     */
+    public VariationsMap getVariationsMap() {
+        return variationsMap;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -479,6 +479,13 @@ public class ConstructorIO {
                 }
             }
 
+            if (req.getVariationsMap() != null) {
+                String variationsMapJson = new Gson().toJson(req.getVariationsMap());
+                url = url.newBuilder()
+                        .addQueryParameter("variations_map", variationsMapJson)
+                        .build();
+            }
+
             Request request = this.makeUserRequestBuilder(userInfo)
                 .url(url)
                 .get()
@@ -552,6 +559,13 @@ public class ConstructorIO {
             if (req.getCollectionId() != null) {
                 url = url.newBuilder()
                 .addQueryParameter("collection_id", req.getCollectionId())
+                .build();
+            }
+
+            if (req.getVariationsMap() != null) {
+                String variationsMapJson = new Gson().toJson(req.getVariationsMap());
+                url = url.newBuilder()
+                .addQueryParameter("variations_map", variationsMapJson)
                 .build();
             }
 
@@ -701,6 +715,13 @@ public class ConstructorIO {
                     .addQueryParameter("sort_by", req.getSortBy())
                     .addQueryParameter("sort_order", req.getSortAscending() ? "ascending" : "descending")
                     .build();
+            }
+
+            if (req.getVariationsMap() != null) {
+                String variationsMapJson = new Gson().toJson(req.getVariationsMap());
+                url = url.newBuilder()
+                        .addQueryParameter("variations_map", variationsMapJson)
+                        .build();
             }
 
             Request request = this.makeUserRequestBuilder(userInfo)
@@ -1189,6 +1210,13 @@ public class ConstructorIO {
                         .addQueryParameter("item_id", itemId)
                         .build();
                 }
+            }
+
+            if (req.getVariationsMap() != null) {
+                String variationsMapJson = new Gson().toJson(req.getVariationsMap());
+                url = url.newBuilder()
+                        .addQueryParameter("variations_map", variationsMapJson)
+                        .build();
             }
 
             Request request = this.makeUserRequestBuilder(userInfo)

--- a/constructorio-client/src/main/java/io/constructor/client/RecommendationsRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/RecommendationsRequest.java
@@ -11,6 +11,7 @@ public class RecommendationsRequest {
     private int numResults;
     private List<String> itemIds;
     private String section;
+    private VariationsMap variationsMap;
 
     /**
      * Creates a recommendations request
@@ -26,6 +27,7 @@ public class RecommendationsRequest {
       this.numResults = 10;
       this.itemIds = null;
       this.section = "Products";
+      this.variationsMap = null;
     }
 
     /**
@@ -82,5 +84,19 @@ public class RecommendationsRequest {
      */
     public String getSection() {
       return section;
+    }
+
+    /**
+     * @param variationsMap the variationsMap to set
+     */
+    public void setVariationsMap(VariationsMap variationsMap) {
+        this.variationsMap = variationsMap;
+    }
+
+    /**
+     * @return the variations map
+     */
+    public VariationsMap getVariationsMap() {
+        return variationsMap;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
@@ -22,6 +22,7 @@ public class SearchRequest {
     private Map<String, String>formatOptions;
     private List<String> hiddenFields;
     private List<String> hiddenFacets;
+    private VariationsMap variationsMap;
 
     /**
      * Creates a search request
@@ -42,6 +43,7 @@ public class SearchRequest {
       this.formatOptions = new HashMap<String, String>();
       this.hiddenFields = new ArrayList<String>();
       this.hiddenFacets = new ArrayList<String>();
+      this.variationsMap = null;
     }
 
     /**
@@ -210,5 +212,19 @@ public class SearchRequest {
      */
     public List<String> getHiddenFacets() {
       return hiddenFacets;
+    }
+
+    /**
+     * @param variationsMap the variationsMap to set
+     */
+    public void setVariationsMap(VariationsMap variationsMap) {
+        this.variationsMap = variationsMap;
+    }
+
+    /**
+     * @return the variations map
+     */
+    public VariationsMap getVariationsMap() {
+        return variationsMap;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/VariationsMap.java
+++ b/constructorio-client/src/main/java/io/constructor/client/VariationsMap.java
@@ -1,0 +1,148 @@
+package io.constructor.client;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+/**
+ * Constructor.io Variations Map Object ... uses Gson/Reflection to load data in
+ */
+public class VariationsMap {
+
+    public class Value {
+        @SerializedName("aggregation")
+        public AggregationTypes aggregation;
+
+        @SerializedName("field")
+        public String field;
+
+        public Value(AggregationTypes aggregation, String field) {
+            this.aggregation = aggregation;
+            this.field = field;
+        }
+    }
+
+    public class Group {
+        @SerializedName("name")
+        public String name;
+
+        @SerializedName("field")
+        public String field;
+
+        public Group(String name, String field) {
+            this.name = name;
+            this.field = field;
+        }
+    }
+
+    public enum Dtypes {
+        @SerializedName("object")
+        object,
+        @SerializedName("array")
+        array,
+    }
+
+    public enum AggregationTypes {
+        @SerializedName("first")
+        first,
+        @SerializedName("min")
+        min,
+        @SerializedName("max")
+        max,
+        @SerializedName("all")
+        all,
+    }
+
+    @SerializedName("dtype")
+    private Dtypes dType;
+
+    @SerializedName("values")
+    private Map<String, Value> values;
+
+    @SerializedName("group_by")
+    private List<Group> groupBy;
+
+    /**
+     * Creates a variations map
+     */
+    public VariationsMap() {
+        this.groupBy = new ArrayList<Group>();
+        this.values = new HashMap<String, Value>();
+        this.dType = Dtypes.array;
+    }
+
+    /**
+     * Creates and adds a group by rule
+     *
+     * @param name The name of the group by rule
+     * @param field The field to group by
+     */
+    public void addGroupByRule(String name, String field) {
+        if (this.groupBy == null) {
+            this.groupBy = new ArrayList<Group>();
+        }
+
+        this.groupBy.add(new Group(name, field));
+    }
+
+    /**
+     * Creates and adds a group by rule
+     *
+     * @param name The name of the value rule
+     * @param aggregation The aggregation type for the rule
+     * @param field The field to group by
+     */
+    public void addValueRule(String name, AggregationTypes aggregation, String field) {
+        if (this.values == null) {
+            this.values = new HashMap<String, Value>();
+        }
+
+        this.values.put(name, new Value(aggregation, field));
+    }
+
+    /**
+     * @return the dtype
+     */
+    public Dtypes getdType() {
+        return dType;
+    }
+
+    /**
+     * @param dType the dtype to set
+     */
+    public void setdType(Dtypes dType) {
+        this.dType = dType;
+    }
+
+    /**
+     * @return the value rules
+     */
+    public Map<String, Value> getValues() {
+        return values;
+    }
+
+    /**
+     * @param values the value rules to set
+     */
+    public void setValues(Map<String, Value> values) {
+        this.values = values;
+    }
+
+    /**
+     * @return the group by rules
+     */
+    public List<Group> getGroupBy() {
+        return groupBy;
+    }
+
+    /**
+     * @param groupBy the group by rules to set
+     */
+    public void setGroupBy(List<Group> groupBy) {
+        this.groupBy = groupBy;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/Result.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Result.java
@@ -21,6 +21,9 @@ public class Result {
   @SerializedName("variations")
   private List<Result> variations;
 
+  @SerializedName("variations_map")
+  private Object variationsMap;
+
   /**
    * @return the value
    */
@@ -47,5 +50,12 @@ public class Result {
    */
   public List<Result> getVariations() {
     return variations;
+  }
+
+  /**
+   * @return the variationsMap
+   */
+  public Object getVariationsMap() {
+    return variationsMap;
   }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -4,10 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Predicate;
 import java.util.Map;
 
+import com.google.gson.Gson;
+import com.google.gson.internal.LinkedTreeMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -232,4 +235,51 @@ public class ConstructorIOBrowseTest {
         assertTrue("browse result [root] has data field", root.getData() instanceof Map);
         assertEquals("browse result [root] has data field and it's empty", root.getData().size(), 0);
     }
+
+    @Test
+    public void BrowseShouldReturnAResultProvidedVariationsMapAsArray() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        BrowseRequest request = new BrowseRequest("Brand", "XYZ");
+        VariationsMap variationsMap = new VariationsMap();
+        variationsMap.setdType(VariationsMap.Dtypes.array);
+        variationsMap.addGroupByRule("variation", "data.variation_id");
+        variationsMap.addValueRule("size", VariationsMap.AggregationTypes.first, "data.facets.size");
+        request.setVariationsMap(variationsMap);
+        BrowseResponse response = constructor.browse(request, userInfo);
+
+        String json = new Gson().toJson(response.getRequest().get("variations_map"));
+        VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
+        ArrayList<Object> varMapObject = (ArrayList<Object>) response.getResponse().getResults().get(0).getVariationsMap();
+
+        assertNotNull("variations map exists", response.getRequest().get("variations_map"));
+        assertEquals("variations map is correct", variationsMap.getdType(), variationsMapFromResponse.getdType());
+        assertTrue("result contains variations_map", varMapObject.size() >= 1);
+        assertEquals("variations map values is correct", variationsMap.getValues().get("size").aggregation, variationsMapFromResponse.getValues().get("size").aggregation);
+        assertEquals("variations map group by is correct", variationsMap.getGroupBy().get(0).field, variationsMapFromResponse.getGroupBy().get(0).field);
+    }
+
+    @Test
+    public void BrowseShouldReturnAResultProvidedVariationsMapAsObject() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        BrowseRequest request = new BrowseRequest("Brand", "XYZ");
+        VariationsMap variationsMap = new VariationsMap();
+        variationsMap.setdType(VariationsMap.Dtypes.object);
+        variationsMap.addGroupByRule("variation", "data.variation_id");
+        variationsMap.addValueRule("size", VariationsMap.AggregationTypes.first, "data.facets.size");
+        request.setVariationsMap(variationsMap);
+        BrowseResponse response = constructor.browse(request, userInfo);
+
+        String json = new Gson().toJson(response.getRequest().get("variations_map"));
+        VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
+        LinkedTreeMap<String, Object> varMapObject = (LinkedTreeMap<String, Object>) response.getResponse().getResults().get(0).getVariationsMap();
+
+        assertNotNull("variations map exists", response.getRequest().get("variations_map"));
+        assertEquals("variations map is correct", variationsMap.getdType(), variationsMapFromResponse.getdType());
+        assertTrue("result contains variations_map", varMapObject.size() >= 1);
+        assertEquals("variations map values is correct", variationsMap.getValues().get("size").aggregation, variationsMapFromResponse.getValues().get("size").aggregation);
+        assertEquals("variations map group by is correct", variationsMap.getGroupBy().get(0).field, variationsMapFromResponse.getGroupBy().get(0).field);
+    }
+
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIORecommendationsTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIORecommendationsTest.java
@@ -1,15 +1,15 @@
 package io.constructor.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Arrays;
 
+import com.google.gson.Gson;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import io.constructor.client.models.RecommendationsResponse;
+
+import static org.junit.Assert.*;
 
 public class ConstructorIORecommendationsTest {
 
@@ -63,5 +63,27 @@ public class ConstructorIORecommendationsTest {
         RecommendationsResponse response = constructor.recommendations(request, userInfo);
         assertTrue("recommendation results exist", response.getResponse().getResults().size() >= 0);
         assertTrue("recommendation result id exists", response.getResultId() != null);
+    }
+
+    @Test
+    public void getRecommendationsShouldReturnAResultWithVariationsMap() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        RecommendationsRequest request = new RecommendationsRequest("item_page_1");
+        request.setItemIds(Arrays.asList("power_drill", "drill"));
+        VariationsMap variationsMap = new VariationsMap();
+        variationsMap.setdType(VariationsMap.Dtypes.object);
+        variationsMap.addGroupByRule("variation", "data.variation_id");
+        variationsMap.addValueRule("size", VariationsMap.AggregationTypes.first, "data.facets.size");
+        request.setVariationsMap(variationsMap);
+        RecommendationsResponse response = constructor.recommendations(request, userInfo);
+
+        String json = new Gson().toJson(response.getRequest().get("variations_map"));
+        VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
+
+        assertNotNull("variations map exists", response.getRequest().get("variations_map"));
+        assertEquals("variations map is correct", variationsMap.getdType(), variationsMapFromResponse.getdType());
+        assertEquals("variations map values is correct", variationsMap.getValues().get("size").aggregation, variationsMapFromResponse.getValues().get("size").aggregation);
+        assertEquals("variations map group by is correct", variationsMap.getGroupBy().get(0).field, variationsMapFromResponse.getGroupBy().get(0).field);
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTaskTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTaskTest.java
@@ -2,6 +2,7 @@ package io.constructor.client;
 
 import io.constructor.client.models.Task;
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.core.StringContains;
 import org.json.JSONObject;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -97,7 +98,7 @@ public class ConstructorIOTaskTest {
         TaskRequest request = new TaskRequest(String.valueOf(task_id));
 
         thrown.expect(ConstructorException.class);
-        thrown.expectMessage("[HTTP 400] We have no record of this key. You can find your key at app.constructor.io/dashboard.");
+        thrown.expectMessage(StringContains.containsString("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`."));
         Task response = constructor.task(request);
     }
 
@@ -107,7 +108,7 @@ public class ConstructorIOTaskTest {
         TaskRequest request = new TaskRequest(String.valueOf(task_id));
 
         thrown.expect(ConstructorException.class);
-        thrown.expectMessage("[HTTP 400] We have no record of this key. You can find your key at app.constructor.io/dashboard.");
+        thrown.expectMessage(StringContains.containsString("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`."));
         String response = constructor.taskAsJson(request);
     }
 

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTasksTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOTasksTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import io.constructor.client.models.AllTasksResponse;
 import io.constructor.client.models.Task;
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.core.StringContains;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.AfterClass;
@@ -138,7 +139,7 @@ public class ConstructorIOTasksTest {
         AllTasksRequest request = new AllTasksRequest();
 
         thrown.expect(ConstructorException.class);
-        thrown.expectMessage("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`. You can find your key at app.constructor.io/dashboard/accounts/api_integration.");
+        thrown.expectMessage(StringContains.containsString("[HTTP 401] You have supplied an invalid `key` or `autocomplete_key`."));
         String response = constructor.allTasksAsJson(request);
     }
 


### PR DESCRIPTION
I was following the c# code as example so I used an enum for the aggregation and dtype fields. 

This would limit what they could input but make it so that we would have to update whenever variation maps is updated. Should I just make it strings instead?