### PR TITLE
[CSL 1498] Add missing query parameters (Search)

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -508,6 +508,7 @@ public class ConstructorIO {
      */
     protected Request createSearchRequest(SearchRequest req, UserInfo userInfo) throws ConstructorException {
         try {
+            Boolean authorizedRequest = false;
             List<String> paths = Arrays.asList("search", req.getQuery());
             HttpUrl url = (userInfo == null) ? this.makeUrl(paths) : this.makeUrl(paths, userInfo);
             url = url.newBuilder()
@@ -598,7 +599,12 @@ public class ConstructorIO {
                     .build();
             }
 
-            Request request = this.makeUserRequestBuilder(userInfo, true)
+            // Make an authorized request if the `now` parameter is provided
+            if (req.getNow() != null) {
+                authorizedRequest = true;
+            }
+            
+            Request request = this.makeUserRequestBuilder(userInfo, authorizedRequest)
                 .url(url)
                 .get()
                 .build();
@@ -1366,9 +1372,11 @@ public class ConstructorIO {
      */
     protected Builder makeUserRequestBuilder(UserInfo info, Boolean authorizedRequest) {
         Builder builder = makeUserRequestBuilder(info);
+
         if (authorizedRequest) {
             builder.addHeader("Authorization", this.credentials);
         }
+
         return builder;
     }
 

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -586,13 +586,15 @@ public class ConstructorIO {
                     .build();
             }
 
+            if (req.getPage() != 1) {
+                url = url.newBuilder()
+                    .addQueryParameter("page", String.valueOf(req.getPage()))
+                    .build();
+            }
+
             if (req.getOffset() != 0) {
                 url = url.newBuilder()
                     .addQueryParameter("offset", String.valueOf(req.getOffset()))
-                    .build();
-            } else {
-                url = url.newBuilder()
-                    .addQueryParameter("page", String.valueOf(req.getPage()))
                     .build();
             }
 

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -512,7 +512,6 @@ public class ConstructorIO {
             HttpUrl url = (userInfo == null) ? this.makeUrl(paths) : this.makeUrl(paths, userInfo);
             url = url.newBuilder()
                 .addQueryParameter("section", req.getSection())
-                .addQueryParameter("page", String.valueOf(req.getPage()))
                 .addQueryParameter("num_results_per_page", String.valueOf(req.getResultsPerPage()))
                 .build();
 
@@ -558,18 +557,46 @@ public class ConstructorIO {
 
             if (req.getCollectionId() != null) {
                 url = url.newBuilder()
-                .addQueryParameter("collection_id", req.getCollectionId())
-                .build();
+                    .addQueryParameter("collection_id", req.getCollectionId())
+                    .build();
             }
 
             if (req.getVariationsMap() != null) {
                 String variationsMapJson = new Gson().toJson(req.getVariationsMap());
                 url = url.newBuilder()
-                .addQueryParameter("variations_map", variationsMapJson)
-                .build();
+                    .addQueryParameter("variations_map", variationsMapJson)
+                    .build();
             }
 
-            Request request = this.makeUserRequestBuilder(userInfo)
+            if (req.getPreFilterExpression() != null) {
+                url = url.newBuilder()
+                    .addQueryParameter("pre_filter_expression", req.getPreFilterExpression())
+                    .build();
+            }
+
+            if (req.getQsParam() != null) {
+                url = url.newBuilder()
+                    .addQueryParameter("qs", req.getQsParam())
+                    .build();
+            }
+
+            if (req.getNow() != null) {
+                url = url.newBuilder()
+                    .addQueryParameter("now", req.getNow())
+                    .build();
+            }
+
+            if (req.getOffset() != 0) {
+                url = url.newBuilder()
+                    .addQueryParameter("offset", String.valueOf(req.getOffset()))
+                    .build();
+            } else {
+                url = url.newBuilder()
+                    .addQueryParameter("page", String.valueOf(req.getPage()))
+                    .build();
+            }
+
+            Request request = this.makeUserRequestBuilder(userInfo, true)
                 .url(url)
                 .get()
                 .build();
@@ -1325,6 +1352,20 @@ public class ConstructorIO {
         }
         if (info != null && info.getUserAgent() != null) {
             builder.addHeader("User-Agent", info.getUserAgent());
+        }
+        return builder;
+    }
+
+    /**
+     * Creates a builder for an end user request
+     *
+     * @param info user information if available
+     * @return Request Builder
+     */
+    protected Builder makeUserRequestBuilder(UserInfo info, Boolean authorizedRequest) {
+        Builder builder = makeUserRequestBuilder(info);
+        if (authorizedRequest) {
+            builder.addHeader("Authorization", this.credentials);
         }
         return builder;
     }

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -582,9 +582,13 @@ public class ConstructorIO {
             }
 
             if (req.getNow() != null) {
+                // Make an authorized request if the `now` parameter is provided
+                authorizedRequest = true;
+
                 url = url.newBuilder()
                     .addQueryParameter("now", req.getNow())
                     .build();
+
             }
 
             if (req.getPage() != 1) {
@@ -597,11 +601,6 @@ public class ConstructorIO {
                 url = url.newBuilder()
                     .addQueryParameter("offset", String.valueOf(req.getOffset()))
                     .build();
-            }
-
-            // Make an authorized request if the `now` parameter is provided
-            if (req.getNow() != null) {
-                authorizedRequest = true;
             }
             
             Request request = this.makeUserRequestBuilder(userInfo, authorizedRequest)

--- a/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
@@ -265,7 +265,7 @@ public class SearchRequest {
     }
 
     /**
-     * @param now a unix epoch timestamp used to emulate "past" and "future" requests
+     * @param now a unix epoch timestamp used to emulate "past" and "future" requests. Please refer to https://docs.constructor.io/rest_api/search/queries/
      */
     public void setNow(String now) {
       this.now = now;

--- a/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
@@ -23,7 +23,11 @@ public class SearchRequest {
     private List<String> hiddenFields;
     private List<String> hiddenFacets;
     private VariationsMap variationsMap;
-
+    private String preFilterExpression;
+    private String qsParam;
+    private String now;
+    private int offset;
+    
     /**
      * Creates a search request
      *
@@ -44,6 +48,10 @@ public class SearchRequest {
       this.hiddenFields = new ArrayList<String>();
       this.hiddenFacets = new ArrayList<String>();
       this.variationsMap = null;
+      this.preFilterExpression = null;
+      this.qsParam = null;
+      this.now = null;
+      this.offset = 0;
     }
 
     /**
@@ -82,7 +90,7 @@ public class SearchRequest {
     }
 
     /**
-     * @param page the page to set
+     * @param page the page to set (Can't be used together with the 'offset' parameter)
      */
     public void setPage(int page) {
       this.page = page;
@@ -218,13 +226,69 @@ public class SearchRequest {
      * @param variationsMap the variationsMap to set
      */
     public void setVariationsMap(VariationsMap variationsMap) {
-        this.variationsMap = variationsMap;
+      this.variationsMap = variationsMap;
     }
 
     /**
      * @return the variations map
      */
     public VariationsMap getVariationsMap() {
-        return variationsMap;
+      return variationsMap;
+    }
+
+    /**
+     * @param preFilterExpression the faceting expression to scope search results (JSON-encoded query string). Please refer to https://docs.constructor.io/rest_api/collections#add-items-dynamically
+     */
+    public void setPreFilterExpression(String preFilterExpression) {
+      this.preFilterExpression = preFilterExpression;
+    }
+
+    /**
+     * @return the prefilter expression
+    */
+    public String getPreFilterExpression() {
+      return preFilterExpression;
+    }
+
+    /**
+     * @param qsParam any parameters listed in the API documentation can be serialized into a JSON object and parsed through this parameter. Please refer to https://docs.constructor.io/rest_api/search/queries/
+     */
+    public void setQsParam(String qsParam) {
+      this.qsParam = qsParam;
+    }
+
+    /**
+     * @return the qs parameter
+    */
+    public String getQsParam() {
+      return qsParam;
+    }
+
+    /**
+     * @param now a unix epoch timestamp used to emulate "past" and "future" requests
+     */
+    public void setNow(String now) {
+      this.now = now;
+    }
+
+    /**
+     * @return the now parameter
+    */
+    public String getNow() {
+      return now;
+    }
+
+    /**
+     * @param offset the number of results to skip from the beginning (Can't be used together with the 'page' parameter)
+     */
+    public void setOffset(int offset) {
+      this.offset = offset;
+    }
+
+    /**
+     * @return the offset
+    */
+    public int getOffset() {
+      return offset;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
@@ -181,7 +181,7 @@ public class SearchRequest {
     }
 
     /**
-     * @param formatOptions the formatOptions to set
+     * @param formatOptions the formatOptions to set. Please refer to https://docs.constructor.io/rest_api/search/queries for details
      */
     public void setFormatOptions(Map<String, String> formatOptions) {
       this.formatOptions = formatOptions;

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -298,6 +298,7 @@ public class ConstructorIOSearchTest {
         SearchResponse response = constructor.search(request, userInfo);
         String preFilterExpressionFromRequestJsonString = new Gson().toJson(response.getRequest().get("pre_filter_expression"));
 
+        assertTrue("search results exist", response.getResponse().getResults().size() >= 0);
         assertNotNull("pre_filter_expression exists", response.getRequest().get("pre_filter_expression"));
         assertEquals(preFilterExpression, preFilterExpressionFromRequestJsonString);
     }
@@ -313,6 +314,7 @@ public class ConstructorIOSearchTest {
         SearchResponse response = constructor.search(request, userInfo);
         Map<String, List<String>> filtersFromRequest = (Map) response.getRequest().get("filters");
 
+        assertTrue("search results exist", response.getResponse().getResults().size() >= 0);
         assertEquals(Arrays.asList("green"), filtersFromRequest.get("Color"));
     }
 
@@ -326,6 +328,7 @@ public class ConstructorIOSearchTest {
 
         SearchResponse response = constructor.search(request, userInfo);
 
+        assertTrue("search results exist", response.getResponse().getResults().size() >= 0);
         assertNotNull("now exists", response.getRequest().get("now"));
         assertEquals(now, new DecimalFormat("#").format(response.getRequest().get("now")));
     }
@@ -340,6 +343,7 @@ public class ConstructorIOSearchTest {
 
         SearchResponse response = constructor.search(request, userInfo);
 
+        assertTrue("search results exist", response.getResponse().getResults().size() >= 0);
         assertNotNull("offset exists", response.getRequest().get("offset"));
         assertEquals(String.valueOf(offset), new DecimalFormat("#").format(response.getRequest().get("offset")));
     }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -343,4 +343,16 @@ public class ConstructorIOSearchTest {
         assertNotNull("offset exists", response.getRequest().get("offset"));
         assertEquals(String.valueOf(offset), new DecimalFormat("#").format(response.getRequest().get("offset")));
     }
+
+    @Test
+    public void SearchShouldReturnErrorWithPageAndOffset() throws Exception {
+        thrown.expect(ConstructorException.class);
+        thrown.expectMessage("[HTTP 400] You've used both 'page' and 'offset' parameters for pagination. Please, use just one of them");
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null );
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        SearchRequest request = new SearchRequest("Jacket");
+        request.setPage(2);
+        request.setOffset(5);
+        constructor.search(request, userInfo);
+    }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -5,12 +5,16 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -22,6 +26,7 @@ import io.constructor.client.models.SearchResponse;
 public class ConstructorIOSearchTest {
 
     private String apiKey = System.getenv("TEST_API_KEY");
+    private String apiToken = System.getenv("TEST_API_TOKEN");
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -280,5 +285,62 @@ public class ConstructorIOSearchTest {
         assertTrue("result contains variations_map", varMapObject.size() >= 1);
         assertEquals("variations map values is correct", variationsMap.getValues().get("size").aggregation, variationsMapFromResponse.getValues().get("size").aggregation);
         assertEquals("variations map group by is correct", variationsMap.getGroupBy().get(0).field, variationsMapFromResponse.getGroupBy().get(0).field);
+    }
+
+    @Test
+    public void SearchShouldReturnAResultWithPreFilterExpression() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null );
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        SearchRequest request = new SearchRequest("Jacket");
+        String preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}";
+        request.setPreFilterExpression(preFilterExpression);
+
+        SearchResponse response = constructor.search(request, userInfo);
+        String preFilterExpressionFromRequestJsonString = new Gson().toJson(response.getRequest().get("pre_filter_expression"));
+
+        assertNotNull("pre_filter_expression exists", response.getRequest().get("pre_filter_expression"));
+        assertEquals(preFilterExpression, preFilterExpressionFromRequestJsonString);
+    }
+
+    @Test
+    public void SearchShouldReturnAResultWithQsParam() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null );
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        SearchRequest request = new SearchRequest("item");
+        String qsParam = "{\"filters\":{\"Color\":[\"green\"]}}";
+        request.setQsParam(qsParam);
+
+        SearchResponse response = constructor.search(request, userInfo);
+        Map<String, List<String>> filtersFromRequest = (Map) response.getRequest().get("filters");
+
+        assertEquals(Arrays.asList("green"), filtersFromRequest.get("Color"));
+    }
+
+    @Test
+    public void SearchShouldReturnAResultWithNow() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(apiToken, apiKey, true, null );
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        SearchRequest request = new SearchRequest("Jacket");
+        String now = "1659053211";
+        request.setNow(now);
+
+        SearchResponse response = constructor.search(request, userInfo);
+
+        assertNotNull("now exists", response.getRequest().get("now"));
+        assertEquals(now, new DecimalFormat("#").format(response.getRequest().get("now")));
+    }
+
+    @Test
+    public void SearchShouldReturnAResultWithOffset() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null );
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        SearchRequest request = new SearchRequest("Jacket");
+        int offset = 5;
+        request.setOffset(offset);
+
+        SearchResponse response = constructor.search(request, userInfo);
+
+        assertNotNull("offset exists", response.getRequest().get("offset"));
+        assertEquals(String.valueOf(offset), new DecimalFormat("#").format(response.getRequest().get("offset")));
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchUrlEncodingTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchUrlEncodingTest.java
@@ -42,7 +42,7 @@ public class ConstructorIOSearchUrlEncodingTest {
         constructor.search(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath = String.format("/search/r%%2Bco?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30&page=1", apiKey);
+        String expectedPath = String.format("/search/r%%2Bco?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }
@@ -58,7 +58,7 @@ public class ConstructorIOSearchUrlEncodingTest {
         constructor.search(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath = String.format("/search/r%%20co?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30&page=1", apiKey);
+        String expectedPath = String.format("/search/r%%20co?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }
@@ -74,7 +74,7 @@ public class ConstructorIOSearchUrlEncodingTest {
         constructor.search(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath = String.format("/search/r%%2Fco?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30&page=1", apiKey);
+        String expectedPath = String.format("/search/r%%2Fco?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }
@@ -90,7 +90,7 @@ public class ConstructorIOSearchUrlEncodingTest {
         constructor.search(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath = String.format("/search/r'co?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30&page=1", apiKey);
+        String expectedPath = String.format("/search/r'co?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchUrlEncodingTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchUrlEncodingTest.java
@@ -42,7 +42,7 @@ public class ConstructorIOSearchUrlEncodingTest {
         constructor.search(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath = String.format("/search/r%%2Bco?key=%s&c=ciojava-5.18.0&section=Products&page=1&num_results_per_page=30", apiKey);
+        String expectedPath = String.format("/search/r%%2Bco?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30&page=1", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }
@@ -58,7 +58,7 @@ public class ConstructorIOSearchUrlEncodingTest {
         constructor.search(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath = String.format("/search/r%%20co?key=%s&c=ciojava-5.18.0&section=Products&page=1&num_results_per_page=30", apiKey);
+        String expectedPath = String.format("/search/r%%20co?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30&page=1", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }
@@ -74,7 +74,7 @@ public class ConstructorIOSearchUrlEncodingTest {
         constructor.search(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath = String.format("/search/r%%2Fco?key=%s&c=ciojava-5.18.0&section=Products&page=1&num_results_per_page=30", apiKey);
+        String expectedPath = String.format("/search/r%%2Fco?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30&page=1", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }
@@ -90,7 +90,7 @@ public class ConstructorIOSearchUrlEncodingTest {
         constructor.search(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath = String.format("/search/r'co?key=%s&c=ciojava-5.18.0&section=Products&page=1&num_results_per_page=30", apiKey);
+        String expectedPath = String.format("/search/r'co?key=%s&c=ciojava-5.18.0&section=Products&num_results_per_page=30&page=1", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }

--- a/constructorio-client/src/test/java/io/constructor/client/SearchRequestTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/SearchRequestTest.java
@@ -44,6 +44,10 @@ public class SearchRequestTest {
         assertNull(request.getSortBy());
         assertTrue(request.getSortAscending());
         assertNull(request.getCollectionId());
+        assertNull(request.getPreFilterExpression());
+        assertNull(request.getQsParam());
+        assertNull(request.getNow());
+        assertEquals(request.getOffset(), 0);
     }
 
     @Test
@@ -56,6 +60,10 @@ public class SearchRequestTest {
         formatOptions.put("groups_start", "top");
         List<String> hiddenFields = Arrays.asList("hiddenField1", "hiddenField2");
         List<String> hiddenFacets = Arrays.asList("hiddenFacet1", "hiddenFacet2");
+        String preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800,\"inf\"]}}]}]}";
+        String qsParam = "{\"num_results_per_page\":\"10\",\"filters\":{\"keywords\":[\"battery-powered\"]}}";
+        String now = "1659049486";
+        int offset = 2;
         
         request.setQuery("airline tickets");
         request.setSection("Search Suggestions");
@@ -69,6 +77,10 @@ public class SearchRequestTest {
         request.setFormatOptions(formatOptions);
         request.setHiddenFields(hiddenFields);
         request.setHiddenFacets(hiddenFacets);
+        request.setPreFilterExpression(preFilterExpression);
+        request.setQsParam(qsParam);
+        request.setNow(now);
+        request.setOffset(offset);
         
         assertEquals(request.getQuery(), "airline tickets");
         assertEquals(request.getSection(), "Search Suggestions");
@@ -82,5 +94,10 @@ public class SearchRequestTest {
         assertEquals(request.getFormatOptions(), formatOptions);
         assertEquals(request.getHiddenFields(), hiddenFields);
         assertEquals(request.getHiddenFacets(), hiddenFacets);
+        assertEquals(request.getPreFilterExpression(), preFilterExpression);
+        assertEquals(request.getQsParam(), qsParam);
+        assertEquals(request.getNow(), now);
+        assertEquals(request.getOffset(), offset);
+
     }
 }


### PR DESCRIPTION
### Updates:
* Added the following missing query params: `qs`, `now`, `pre_filter_expression`, `offset`
* All tests pass