### PR TITLE
[CSL 1581] Update okhttp3 and json to new versions

### DIFF
--- a/constructorio-client/pom.xml
+++ b/constructorio-client/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.14.9</version>
+			<version>4.9.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -36,13 +36,13 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>logging-interceptor</artifactId>
-			<version>3.14.9</version>
+			<version>4.9.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>3.14.9</version>
+			<version>4.9.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/constructorio-client/pom.xml
+++ b/constructorio-client/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20140107</version>
+			<version>20180130</version>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
### Updates:
* Update okhttp3 to `v4.9.2`
* Update json to `20180130`

### Notes:
* Updating okhttp3 to the newer version caused compilation errors when running tests
    * Required copying `decodeHexDigit` function from the older version of okhttp3
    * Required adding a try/catch block to handle the EOFException in the `canonicalize` function