### PR TITLE
[CSL-2396] Update org.json dependency

### DIFF
--- a/constructorio-client/pom.xml
+++ b/constructorio-client/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20180130</version>
+			<version>20230227</version>
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
All tests pass ✅

According to the [releases page of org.json](https://github.com/stleary/JSON-java/blob/master/docs/RELEASES.md), the only possibly breaking change was in `JSONPointer` and we don't use that. They also changed their LICENSE to public domain which is the least restricting