### PR TITLE
[CI-3556] Add Path List to ResultGroup Object

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/models/ResultGroup.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/ResultGroup.java
@@ -1,5 +1,7 @@
 package io.constructor.client.models;
 
+import java.util.List;
+
 import com.google.gson.annotations.SerializedName;
 
 /** Constructor.io Item Group ... uses Gson/Reflection to load data in */
@@ -13,6 +15,9 @@ public class ResultGroup {
 
     @SerializedName("path")
     private String path;
+
+    @SerializedName("path_list")
+    private List<ResultGroupPathListItem> pathList;
 
     /**
      * @return the displayName
@@ -35,6 +40,13 @@ public class ResultGroup {
         return path;
     }
 
+    /**
+     * @return the pathList
+     */
+    public List<ResultGroupPathListItem> getPathList() {
+        return pathList;
+    }
+
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
     }
@@ -45,5 +57,9 @@ public class ResultGroup {
 
     public void setPath(String path) {
         this.path = path;
+    }
+
+    public void setPathList(List<ResultGroupPathListItem> pathList) {
+        this.pathList = pathList;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/ResultGroup.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/ResultGroup.java
@@ -1,8 +1,7 @@
 package io.constructor.client.models;
 
-import java.util.List;
-
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
 
 /** Constructor.io Item Group ... uses Gson/Reflection to load data in */
 public class ResultGroup {

--- a/constructorio-client/src/main/java/io/constructor/client/models/ResultGroupPathListItem.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/ResultGroupPathListItem.java
@@ -1,0 +1,34 @@
+package io.constructor.client.models;
+
+import com.google.gson.annotations.SerializedName;
+
+/** Constructor.io Item Group ... uses Gson/Reflection to load data in */
+public class ResultGroupPathListItem {
+  @SerializedName("id")
+  private String id;
+
+  @SerializedName("display_name")
+  private String displayName;
+
+  /**
+   * @return the displayName
+   */
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  /**
+   * @return the groupId
+   */
+  public String getId() {
+    return id;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public void setGroupId(String id) {
+    this.id = id;
+  }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/ResultGroupPathListItem.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/ResultGroupPathListItem.java
@@ -4,31 +4,31 @@ import com.google.gson.annotations.SerializedName;
 
 /** Constructor.io Item Group ... uses Gson/Reflection to load data in */
 public class ResultGroupPathListItem {
-  @SerializedName("id")
-  private String id;
+    @SerializedName("id")
+    private String id;
 
-  @SerializedName("display_name")
-  private String displayName;
+    @SerializedName("display_name")
+    private String displayName;
 
-  /**
-   * @return the displayName
-   */
-  public String getDisplayName() {
-    return displayName;
-  }
+    /**
+     * @return the displayName
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
 
-  /**
-   * @return the groupId
-   */
-  public String getId() {
-    return id;
-  }
+    /**
+     * @return the groupId
+     */
+    public String getId() {
+        return id;
+    }
 
-  public void setDisplayName(String displayName) {
-    this.displayName = displayName;
-  }
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
 
-  public void setGroupId(String id) {
-    this.id = id;
-  }
+    public void setGroupId(String id) {
+        this.id = id;
+    }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -27,8 +27,7 @@ public class ConstructorIOBrowseTest {
     private String apiKey = System.getenv("TEST_REQUEST_API_KEY");
     private String apiToken = System.getenv("TEST_API_TOKEN");
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void BrowseShouldReturnAResult() throws Exception {
@@ -140,13 +139,14 @@ public class ConstructorIOBrowseTest {
         assertTrue(
                 "browse result variation [facets] exists",
                 response.getResponse()
-                        .getResults()
-                        .get(0)
-                        .getVariations()
-                        .get(0)
-                        .getData()
-                        .getFacets()
-                        .size() > 0);
+                                .getResults()
+                                .get(0)
+                                .getVariations()
+                                .get(0)
+                                .getData()
+                                .getFacets()
+                                .size()
+                        > 0);
         assertEquals(
                 "browse result variation [value] exists",
                 response.getResponse().getResults().get(0).getVariations().get(0).getValue(),
@@ -325,16 +325,17 @@ public class ConstructorIOBrowseTest {
         BrowseRequest request = new BrowseRequest("Brand", "XYZ");
         request.getHiddenFacets().add("Brand");
         BrowseResponse response = constructor.browse(request, userInfo);
-        FilterFacet brandFacet = response.getResponse().getFacets().stream()
-                .filter(
-                        new Predicate<FilterFacet>() {
-                            @Override
-                            public boolean test(FilterFacet f) {
-                                return f.getName().equals("Brand");
-                            }
-                        })
-                .findAny()
-                .orElse(null);
+        FilterFacet brandFacet =
+                response.getResponse().getFacets().stream()
+                        .filter(
+                                new Predicate<FilterFacet>() {
+                                    @Override
+                                    public boolean test(FilterFacet f) {
+                                        return f.getName().equals("Brand");
+                                    }
+                                })
+                        .findAny()
+                        .orElse(null);
 
         assertEquals("browse results exist", response.getResponse().getResults().size(), 4);
         assertNotNull("browse facet [Brand] exists", brandFacet);
@@ -372,8 +373,8 @@ public class ConstructorIOBrowseTest {
 
         String json = new Gson().toJson(response.getRequest().get("variations_map"));
         VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
-        ArrayList<Object> varMapObject = (ArrayList<Object>) response.getResponse().getResults().get(0)
-                .getVariationsMap();
+        ArrayList<Object> varMapObject =
+                (ArrayList<Object>) response.getResponse().getResults().get(0).getVariationsMap();
 
         assertNotNull("variations map exists", response.getRequest().get("variations_map"));
         assertEquals(
@@ -410,8 +411,9 @@ public class ConstructorIOBrowseTest {
 
         String json = new Gson().toJson(response.getRequest().get("variations_map"));
         VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
-        LinkedTreeMap<String, Object> varMapObject = (LinkedTreeMap<String, Object>) response.getResponse()
-                .getResults().get(0).getVariationsMap();
+        LinkedTreeMap<String, Object> varMapObject =
+                (LinkedTreeMap<String, Object>)
+                        response.getResponse().getResults().get(0).getVariationsMap();
 
         assertNotNull("variations map exists", response.getRequest().get("variations_map"));
         assertEquals(
@@ -434,12 +436,13 @@ public class ConstructorIOBrowseTest {
         ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
         BrowseRequest request = new BrowseRequest("Brand", "XYZ");
-        String preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}";
+        String preFilterExpression =
+                "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}";
         request.setPreFilterExpression(preFilterExpression);
 
         BrowseResponse response = constructor.browse(request, userInfo);
-        String preFilterExpressionFromRequestJsonString = new Gson()
-                .toJson(response.getRequest().get("pre_filter_expression"));
+        String preFilterExpressionFromRequestJsonString =
+                new Gson().toJson(response.getRequest().get("pre_filter_expression"));
 
         assertTrue("browse results exist", response.getResponse().getResults().size() >= 0);
         assertNotNull(
@@ -585,10 +588,11 @@ public class ConstructorIOBrowseTest {
         assertTrue(
                 "browse result refined content data [arbitraryDataObject] exists",
                 response.getResponse()
-                        .getRefinedContent()
-                        .get(0)
-                        .getData()
-                        .get("arbitraryDataObject") != null);
+                                .getRefinedContent()
+                                .get(0)
+                                .getData()
+                                .get("arbitraryDataObject")
+                        != null);
         assertTrue("browse result id exists", response.getResultId() != null);
         assertTrue("request exists", response.getRequest() != null);
     }
@@ -613,7 +617,10 @@ public class ConstructorIOBrowseTest {
 
         List<ResultGroupPathListItem> groupPathList = group.getPathList();
         assertTrue("pathList exists", groupPathList.size() > 0);
-        assertEquals("first pathListItem displayName matches", groupPathList.get(0).getDisplayName(), "All");
+        assertEquals(
+                "first pathListItem displayName matches",
+                groupPathList.get(0).getDisplayName(),
+                "All");
         assertEquals("first pathListItem id matches", groupPathList.get(0).getId(), "All");
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -9,6 +9,9 @@ import com.google.gson.internal.LinkedTreeMap;
 import io.constructor.client.models.BrowseResponse;
 import io.constructor.client.models.FilterFacet;
 import io.constructor.client.models.FilterGroup;
+import io.constructor.client.models.Result;
+import io.constructor.client.models.ResultGroup;
+import io.constructor.client.models.ResultGroupPathListItem;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,7 +27,8 @@ public class ConstructorIOBrowseTest {
     private String apiKey = System.getenv("TEST_REQUEST_API_KEY");
     private String apiToken = System.getenv("TEST_API_TOKEN");
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void BrowseShouldReturnAResult() throws Exception {
@@ -136,14 +140,13 @@ public class ConstructorIOBrowseTest {
         assertTrue(
                 "browse result variation [facets] exists",
                 response.getResponse()
-                                .getResults()
-                                .get(0)
-                                .getVariations()
-                                .get(0)
-                                .getData()
-                                .getFacets()
-                                .size()
-                        > 0);
+                        .getResults()
+                        .get(0)
+                        .getVariations()
+                        .get(0)
+                        .getData()
+                        .getFacets()
+                        .size() > 0);
         assertEquals(
                 "browse result variation [value] exists",
                 response.getResponse().getResults().get(0).getVariations().get(0).getValue(),
@@ -322,17 +325,16 @@ public class ConstructorIOBrowseTest {
         BrowseRequest request = new BrowseRequest("Brand", "XYZ");
         request.getHiddenFacets().add("Brand");
         BrowseResponse response = constructor.browse(request, userInfo);
-        FilterFacet brandFacet =
-                response.getResponse().getFacets().stream()
-                        .filter(
-                                new Predicate<FilterFacet>() {
-                                    @Override
-                                    public boolean test(FilterFacet f) {
-                                        return f.getName().equals("Brand");
-                                    }
-                                })
-                        .findAny()
-                        .orElse(null);
+        FilterFacet brandFacet = response.getResponse().getFacets().stream()
+                .filter(
+                        new Predicate<FilterFacet>() {
+                            @Override
+                            public boolean test(FilterFacet f) {
+                                return f.getName().equals("Brand");
+                            }
+                        })
+                .findAny()
+                .orElse(null);
 
         assertEquals("browse results exist", response.getResponse().getResults().size(), 4);
         assertNotNull("browse facet [Brand] exists", brandFacet);
@@ -370,8 +372,8 @@ public class ConstructorIOBrowseTest {
 
         String json = new Gson().toJson(response.getRequest().get("variations_map"));
         VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
-        ArrayList<Object> varMapObject =
-                (ArrayList<Object>) response.getResponse().getResults().get(0).getVariationsMap();
+        ArrayList<Object> varMapObject = (ArrayList<Object>) response.getResponse().getResults().get(0)
+                .getVariationsMap();
 
         assertNotNull("variations map exists", response.getRequest().get("variations_map"));
         assertEquals(
@@ -408,9 +410,8 @@ public class ConstructorIOBrowseTest {
 
         String json = new Gson().toJson(response.getRequest().get("variations_map"));
         VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
-        LinkedTreeMap<String, Object> varMapObject =
-                (LinkedTreeMap<String, Object>)
-                        response.getResponse().getResults().get(0).getVariationsMap();
+        LinkedTreeMap<String, Object> varMapObject = (LinkedTreeMap<String, Object>) response.getResponse()
+                .getResults().get(0).getVariationsMap();
 
         assertNotNull("variations map exists", response.getRequest().get("variations_map"));
         assertEquals(
@@ -433,13 +434,12 @@ public class ConstructorIOBrowseTest {
         ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
         BrowseRequest request = new BrowseRequest("Brand", "XYZ");
-        String preFilterExpression =
-                "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}";
+        String preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}";
         request.setPreFilterExpression(preFilterExpression);
 
         BrowseResponse response = constructor.browse(request, userInfo);
-        String preFilterExpressionFromRequestJsonString =
-                new Gson().toJson(response.getRequest().get("pre_filter_expression"));
+        String preFilterExpressionFromRequestJsonString = new Gson()
+                .toJson(response.getRequest().get("pre_filter_expression"));
 
         assertTrue("browse results exist", response.getResponse().getResults().size() >= 0);
         assertNotNull(
@@ -585,12 +585,35 @@ public class ConstructorIOBrowseTest {
         assertTrue(
                 "browse result refined content data [arbitraryDataObject] exists",
                 response.getResponse()
-                                .getRefinedContent()
-                                .get(0)
-                                .getData()
-                                .get("arbitraryDataObject")
-                        != null);
+                        .getRefinedContent()
+                        .get(0)
+                        .getData()
+                        .get("arbitraryDataObject") != null);
         assertTrue("browse result id exists", response.getResultId() != null);
         assertTrue("request exists", response.getRequest() != null);
+    }
+
+    @Test
+    public void BrowseShouldReturnItemLevelGroupsObject() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        BrowseRequest request = new BrowseRequest("group_id", "BrandA");
+        BrowseResponse response = constructor.browse(request, userInfo);
+
+        List<Result> resultsList = response.getResponse().getResults();
+        assertTrue("search results exist", resultsList.size() > 0);
+
+        List<ResultGroup> groupsList = resultsList.get(0).getData().getGroups();
+        assertTrue("groups at the item level exist", groupsList.size() > 0);
+
+        ResultGroup group = groupsList.get(0);
+        assertEquals("group displayName matches", group.getDisplayName(), "BrandA");
+        assertEquals("group groupId matches", group.getGroupId(), "BrandA");
+        assertEquals("group path matches", group.getPath(), "/All/Brands");
+
+        List<ResultGroupPathListItem> groupPathList = group.getPathList();
+        assertTrue("pathList exists", groupPathList.size() > 0);
+        assertEquals("first pathListItem displayName matches", groupPathList.get(0).getDisplayName(), "All");
+        assertEquals("first pathListItem id matches", groupPathList.get(0).getId(), "All");
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -28,8 +28,7 @@ public class ConstructorIOSearchTest {
     private String apiKey = System.getenv("TEST_REQUEST_API_KEY");
     private String apiToken = System.getenv("TEST_API_TOKEN");
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void SearchAsJSONShouldReturnAResult() throws Exception {
@@ -138,13 +137,14 @@ public class ConstructorIOSearchTest {
         assertTrue(
                 "search result variation [facets] exists",
                 response.getResponse()
-                        .getResults()
-                        .get(0)
-                        .getVariations()
-                        .get(0)
-                        .getData()
-                        .getFacets()
-                        .size() > 0);
+                                .getResults()
+                                .get(0)
+                                .getVariations()
+                                .get(0)
+                                .getData()
+                                .getFacets()
+                                .size()
+                        > 0);
         assertEquals(
                 "search result variation [value] exists",
                 response.getResponse().getResults().get(0).getVariations().get(0).getValue(),
@@ -314,16 +314,17 @@ public class ConstructorIOSearchTest {
         request.getHiddenFacets().add("Brand");
 
         SearchResponse response = constructor.search(request, userInfo);
-        FilterFacet brandFacet = response.getResponse().getFacets().stream()
-                .filter(
-                        new Predicate<FilterFacet>() {
-                            @Override
-                            public boolean test(FilterFacet f) {
-                                return f.getName().equals("Brand");
-                            }
-                        })
-                .findAny()
-                .orElse(null);
+        FilterFacet brandFacet =
+                response.getResponse().getFacets().stream()
+                        .filter(
+                                new Predicate<FilterFacet>() {
+                                    @Override
+                                    public boolean test(FilterFacet f) {
+                                        return f.getName().equals("Brand");
+                                    }
+                                })
+                        .findAny()
+                        .orElse(null);
 
         assertTrue("search results exist", response.getResponse().getResults().size() >= 5);
         assertNotNull("search facet [Brand] exists", brandFacet);
@@ -364,8 +365,8 @@ public class ConstructorIOSearchTest {
 
         String json = new Gson().toJson(response.getRequest().get("variations_map"));
         VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
-        ArrayList<Object> varMapObject = (ArrayList<Object>) response.getResponse().getResults().get(0)
-                .getVariationsMap();
+        ArrayList<Object> varMapObject =
+                (ArrayList<Object>) response.getResponse().getResults().get(0).getVariationsMap();
 
         assertNotNull("variations map exists", response.getRequest().get("variations_map"));
         assertEquals(
@@ -402,8 +403,9 @@ public class ConstructorIOSearchTest {
 
         String json = new Gson().toJson(response.getRequest().get("variations_map"));
         VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
-        LinkedTreeMap<String, Object> varMapObject = (LinkedTreeMap<String, Object>) response.getResponse()
-                .getResults().get(0).getVariationsMap();
+        LinkedTreeMap<String, Object> varMapObject =
+                (LinkedTreeMap<String, Object>)
+                        response.getResponse().getResults().get(0).getVariationsMap();
 
         assertNotNull("variations map exists", response.getRequest().get("variations_map"));
         assertEquals(
@@ -426,12 +428,13 @@ public class ConstructorIOSearchTest {
         ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
         SearchRequest request = new SearchRequest("Jacket");
-        String preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}";
+        String preFilterExpression =
+                "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}";
         request.setPreFilterExpression(preFilterExpression);
 
         SearchResponse response = constructor.search(request, userInfo);
-        String preFilterExpressionFromRequestJsonString = new Gson()
-                .toJson(response.getRequest().get("pre_filter_expression"));
+        String preFilterExpressionFromRequestJsonString =
+                new Gson().toJson(response.getRequest().get("pre_filter_expression"));
 
         assertTrue("search results exist", response.getResponse().getResults().size() >= 0);
         assertNotNull(
@@ -578,10 +581,11 @@ public class ConstructorIOSearchTest {
         assertTrue(
                 "search result refined content data [arbitraryDataObject] exists",
                 response.getResponse()
-                        .getRefinedContent()
-                        .get(0)
-                        .getData()
-                        .get("arbitraryDataObject") != null);
+                                .getRefinedContent()
+                                .get(0)
+                                .getData()
+                                .get("arbitraryDataObject")
+                        != null);
         assertTrue("search result id exists", response.getResultId() != null);
         assertTrue("request exists", response.getRequest() != null);
         assertEquals("request query exists", response.getRequest().get("term"), "item");
@@ -607,7 +611,10 @@ public class ConstructorIOSearchTest {
 
         List<ResultGroupPathListItem> groupPathList = group.getPathList();
         assertTrue("pathList exists", groupPathList.size() > 0);
-        assertEquals("first pathListItem displayName matches", groupPathList.get(0).getDisplayName(), "All");
+        assertEquals(
+                "first pathListItem displayName matches",
+                groupPathList.get(0).getDisplayName(),
+                "All");
         assertEquals("first pathListItem id matches", groupPathList.get(0).getId(), "All");
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -9,6 +9,9 @@ import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
 import io.constructor.client.models.FilterFacet;
 import io.constructor.client.models.FilterGroup;
+import io.constructor.client.models.Result;
+import io.constructor.client.models.ResultGroup;
+import io.constructor.client.models.ResultGroupPathListItem;
 import io.constructor.client.models.SearchResponse;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -25,7 +28,8 @@ public class ConstructorIOSearchTest {
     private String apiKey = System.getenv("TEST_REQUEST_API_KEY");
     private String apiToken = System.getenv("TEST_API_TOKEN");
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void SearchAsJSONShouldReturnAResult() throws Exception {
@@ -134,14 +138,13 @@ public class ConstructorIOSearchTest {
         assertTrue(
                 "search result variation [facets] exists",
                 response.getResponse()
-                                .getResults()
-                                .get(0)
-                                .getVariations()
-                                .get(0)
-                                .getData()
-                                .getFacets()
-                                .size()
-                        > 0);
+                        .getResults()
+                        .get(0)
+                        .getVariations()
+                        .get(0)
+                        .getData()
+                        .getFacets()
+                        .size() > 0);
         assertEquals(
                 "search result variation [value] exists",
                 response.getResponse().getResults().get(0).getVariations().get(0).getValue(),
@@ -311,17 +314,16 @@ public class ConstructorIOSearchTest {
         request.getHiddenFacets().add("Brand");
 
         SearchResponse response = constructor.search(request, userInfo);
-        FilterFacet brandFacet =
-                response.getResponse().getFacets().stream()
-                        .filter(
-                                new Predicate<FilterFacet>() {
-                                    @Override
-                                    public boolean test(FilterFacet f) {
-                                        return f.getName().equals("Brand");
-                                    }
-                                })
-                        .findAny()
-                        .orElse(null);
+        FilterFacet brandFacet = response.getResponse().getFacets().stream()
+                .filter(
+                        new Predicate<FilterFacet>() {
+                            @Override
+                            public boolean test(FilterFacet f) {
+                                return f.getName().equals("Brand");
+                            }
+                        })
+                .findAny()
+                .orElse(null);
 
         assertTrue("search results exist", response.getResponse().getResults().size() >= 5);
         assertNotNull("search facet [Brand] exists", brandFacet);
@@ -362,8 +364,8 @@ public class ConstructorIOSearchTest {
 
         String json = new Gson().toJson(response.getRequest().get("variations_map"));
         VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
-        ArrayList<Object> varMapObject =
-                (ArrayList<Object>) response.getResponse().getResults().get(0).getVariationsMap();
+        ArrayList<Object> varMapObject = (ArrayList<Object>) response.getResponse().getResults().get(0)
+                .getVariationsMap();
 
         assertNotNull("variations map exists", response.getRequest().get("variations_map"));
         assertEquals(
@@ -400,9 +402,8 @@ public class ConstructorIOSearchTest {
 
         String json = new Gson().toJson(response.getRequest().get("variations_map"));
         VariationsMap variationsMapFromResponse = new Gson().fromJson(json, VariationsMap.class);
-        LinkedTreeMap<String, Object> varMapObject =
-                (LinkedTreeMap<String, Object>)
-                        response.getResponse().getResults().get(0).getVariationsMap();
+        LinkedTreeMap<String, Object> varMapObject = (LinkedTreeMap<String, Object>) response.getResponse()
+                .getResults().get(0).getVariationsMap();
 
         assertNotNull("variations map exists", response.getRequest().get("variations_map"));
         assertEquals(
@@ -425,13 +426,12 @@ public class ConstructorIOSearchTest {
         ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
         SearchRequest request = new SearchRequest("Jacket");
-        String preFilterExpression =
-                "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}";
+        String preFilterExpression = "{\"or\":[{\"and\":[{\"name\":\"group_id\",\"value\":\"electronics-group-id\"},{\"name\":\"Price\",\"range\":[\"-inf\",200.0]}]},{\"and\":[{\"name\":\"Type\",\"value\":\"Laptop\"},{\"not\":{\"name\":\"Price\",\"range\":[800.0,\"inf\"]}}]}]}";
         request.setPreFilterExpression(preFilterExpression);
 
         SearchResponse response = constructor.search(request, userInfo);
-        String preFilterExpressionFromRequestJsonString =
-                new Gson().toJson(response.getRequest().get("pre_filter_expression"));
+        String preFilterExpressionFromRequestJsonString = new Gson()
+                .toJson(response.getRequest().get("pre_filter_expression"));
 
         assertTrue("search results exist", response.getResponse().getResults().size() >= 0);
         assertNotNull(
@@ -578,13 +578,36 @@ public class ConstructorIOSearchTest {
         assertTrue(
                 "search result refined content data [arbitraryDataObject] exists",
                 response.getResponse()
-                                .getRefinedContent()
-                                .get(0)
-                                .getData()
-                                .get("arbitraryDataObject")
-                        != null);
+                        .getRefinedContent()
+                        .get(0)
+                        .getData()
+                        .get("arbitraryDataObject") != null);
         assertTrue("search result id exists", response.getResultId() != null);
         assertTrue("request exists", response.getRequest() != null);
         assertEquals("request query exists", response.getRequest().get("term"), "item");
+    }
+
+    @Test
+    public void SearchShouldReturnItemLevelGroupsObject() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        SearchRequest request = new SearchRequest("item");
+        SearchResponse response = constructor.search(request, userInfo);
+
+        List<Result> resultsList = response.getResponse().getResults();
+        assertTrue("search results exist", resultsList.size() > 0);
+
+        List<ResultGroup> groupsList = resultsList.get(0).getData().getGroups();
+        assertTrue("groups at the item level exist", groupsList.size() > 0);
+
+        ResultGroup group = groupsList.get(0);
+        assertEquals("group displayName matches", group.getDisplayName(), "BrandXY");
+        assertEquals("group groupId matches", group.getGroupId(), "BrandXY");
+        assertEquals("group path matches", group.getPath(), "/All/Brands/BrandX");
+
+        List<ResultGroupPathListItem> groupPathList = group.getPathList();
+        assertTrue("pathList exists", groupPathList.size() > 0);
+        assertEquals("first pathListItem displayName matches", groupPathList.get(0).getDisplayName(), "All");
+        assertEquals("first pathListItem id matches", groupPathList.get(0).getId(), "All");
     }
 }


### PR DESCRIPTION
## Overview
Add `path_list` to `ResultGroup` model.

### Changes
- New Model: `ResultGroupPathListItem`
  - Field - id: String
  - Field - displayName: String
- Changed Model: `ResultGroup`
  - New Field - pathList: ResultGroupPathListItem
  - New Getter/Setter

### Note
Version_Id for Quizzes seems incorrect for the tests. I'll throw up a story to fix it.