### PR TITLE
[CI-3653] Add support for Create Facet Configuration

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -2770,9 +2770,9 @@ public class ConstructorIO {
         try {
             HttpUrl url = this.makeUrl(Arrays.asList("v1", "facets"));
             url =
-                    url.newBuilder()
-                            .addQueryParameter("section", facetConfigurationRequest.getSection())
-                            .build();
+                url.newBuilder()
+                    .addQueryParameter("section", facetConfigurationRequest.getSection())
+                    .build();
 
             String params = new Gson().toJson(facetConfigurationRequest.geFacetConfiguration());
             RequestBody body =

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -93,6 +93,7 @@ public class ConstructorIO {
         client = builder.build();
         clientWithRetry = builder.retryOnConnectionFailure(true).build();
     }
+
     /**
      * @return the HTTP client used by all instances
      */

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -2764,15 +2764,14 @@ public class ConstructorIO {
      * @return returns the created facet
      * @throws ConstructorException if the request is invalid.
      */
-    public String createFacetConfiguration(
-            FacetConfigurationRequest facetConfigurationRequest)
+    public String createFacetConfiguration(FacetConfigurationRequest facetConfigurationRequest)
             throws ConstructorException {
         try {
             HttpUrl url = this.makeUrl(Arrays.asList("v1", "facets"));
             url =
-                url.newBuilder()
-                    .addQueryParameter("section", facetConfigurationRequest.getSection())
-                    .build();
+                    url.newBuilder()
+                            .addQueryParameter("section", facetConfigurationRequest.getSection())
+                            .build();
 
             String params = new Gson().toJson(facetConfigurationRequest.geFacetConfiguration());
             RequestBody body =

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -2756,4 +2756,34 @@ public class ConstructorIO {
             throw new ConstructorException(exception);
         }
     }
+
+    /**
+     * Create a facet configuration
+     *
+     * @param facetConfigurationRequest the facet configuration request
+     * @return returns the created facet
+     * @throws ConstructorException if the request is invalid.
+     */
+    public String createFacetConfiguration(
+            FacetConfigurationRequest facetConfigurationRequest)
+            throws ConstructorException {
+        try {
+            HttpUrl url = this.makeUrl(Arrays.asList("v1", "facets"));
+            url =
+                    url.newBuilder()
+                            .addQueryParameter("section", facetConfigurationRequest.getSection())
+                            .build();
+
+            String params = new Gson().toJson(facetConfigurationRequest.geFacetConfiguration());
+            RequestBody body =
+                    RequestBody.create(params, MediaType.parse("application/json; charset=utf-8"));
+            Request request = this.makeAuthorizedRequestBuilder().url(url).post(body).build();
+
+            Response response = client.newCall(request).execute();
+
+            return getResponseBody(response);
+        } catch (Exception exception) {
+            throw new ConstructorException(exception);
+        }
+    }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/FacetConfigurationRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/FacetConfigurationRequest.java
@@ -1,0 +1,56 @@
+package io.constructor.client;
+
+import io.constructor.client.models.FacetConfiguration;
+
+/** Constructor.io FacetConfiguration Request */
+public class FacetConfigurationRequest {
+    private FacetConfiguration facetConfiguration;
+    private String section;
+
+    /**
+     * Creates a catalog request
+     *
+     * @param facetConfiguration the facet configuration to be created/updated
+     * @param section the autocomplete section to upload the files to
+     */
+    public FacetConfigurationRequest(FacetConfiguration facetConfiguration, String section) {
+        if (facetConfiguration == null) {
+            throw new IllegalArgumentException("facetConfiguration is required");
+        }
+        if (section == null) {
+            throw new IllegalArgumentException("section is required");
+        }
+
+        this.facetConfiguration = facetConfiguration;
+        this.section = section;
+    }
+
+    /**
+     * @param facetConfiguration the facet configuration to be created/updated
+     */
+    public void setFacetConfiguration(FacetConfiguration facetConfiguration) {
+        this.facetConfiguration = facetConfiguration;
+    }
+
+    /**
+     * @return the facet configuration to be created/updated
+     */
+    public FacetConfiguration geFacetConfiguration() {
+        return facetConfiguration;
+    }
+
+    /**
+     * @param section the section to set
+     */
+    public void setSection(String section) {
+        this.section = section;
+    }
+
+    /**
+     * @return the section
+     * 
+     */
+    public String getSection() {
+        return section;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/FacetConfigurationRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/FacetConfigurationRequest.java
@@ -11,7 +11,7 @@ public class FacetConfigurationRequest {
      * Creates a catalog request
      *
      * @param facetConfiguration the facet configuration to be created/updated
-     * @param section the autocomplete section to upload the files to
+     * @param section            the autocomplete section to upload the files to
      */
     public FacetConfigurationRequest(FacetConfiguration facetConfiguration, String section) {
         if (facetConfiguration == null) {

--- a/constructorio-client/src/main/java/io/constructor/client/FacetConfigurationRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/FacetConfigurationRequest.java
@@ -8,10 +8,10 @@ public class FacetConfigurationRequest {
     private String section;
 
     /**
-     * Creates a catalog request
+     * Creates a facet configuration request
      *
      * @param facetConfiguration the facet configuration to be created/updated
-     * @param section            the autocomplete section to upload the files to
+     * @param section the autocomplete section to upload the files to
      */
     public FacetConfigurationRequest(FacetConfiguration facetConfiguration, String section) {
         if (facetConfiguration == null) {
@@ -48,7 +48,6 @@ public class FacetConfigurationRequest {
 
     /**
      * @return the section
-     * 
      */
     public String getSection() {
         return section;

--- a/constructorio-client/src/main/java/io/constructor/client/models/FacetConfiguration.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/FacetConfiguration.java
@@ -1,13 +1,10 @@
 package io.constructor.client.models;
 
 import com.google.gson.annotations.SerializedName;
-
 import java.util.List;
 import java.util.Map;
 
-/**
- * Constructor.io Facet Configuration ... uses Gson/Reflection to load data in
- */
+/** Constructor.io Facet Configuration ... uses Gson/Reflection to load data in */
 public class FacetConfiguration {
     public enum MatchType {
         all,

--- a/constructorio-client/src/main/java/io/constructor/client/models/FacetConfiguration.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/FacetConfiguration.java
@@ -5,7 +5,9 @@ import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import java.util.Map;
 
-/** Constructor.io Facet Configuration ... uses Gson/Reflection to load data in */
+/**
+ * Constructor.io Facet Configuration ... uses Gson/Reflection to load data in
+ */
 public class FacetConfiguration {
     public enum MatchType {
         all,

--- a/constructorio-client/src/main/java/io/constructor/client/models/FacetConfiguration.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/FacetConfiguration.java
@@ -1,0 +1,253 @@
+package io.constructor.client.models;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+import java.util.Map;
+
+/** Constructor.io Facet Configuration ... uses Gson/Reflection to load data in */
+public class FacetConfiguration {
+    public enum MatchType {
+        all,
+        any,
+        none,
+    }
+
+    @SerializedName("options")
+    private List<FacetOptionConfiguration> options;
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("type")
+    private String type;
+
+    @SerializedName("display_name")
+    private String displayName;
+
+    @SerializedName("sort_order")
+    private String sortOrder;
+
+    @SerializedName("sort_descending")
+    private Boolean sortDescending;
+
+    @SerializedName("range_type")
+    private String rangeType;
+
+    @SerializedName("range_format")
+    private String rangeFormat;
+
+    @SerializedName("range_inclusive")
+    private String rangeInclusive;
+
+    @SerializedName("range_limits")
+    private List<String> rangeLimits;
+
+    @SerializedName("match_type")
+    private MatchType matchType;
+
+    @SerializedName("position")
+    private int position;
+
+    @SerializedName("hidden")
+    private Boolean hidden;
+
+    @SerializedName("protected")
+    private Boolean isProtected;
+
+    @SerializedName("countable")
+    private Boolean countable;
+
+    @SerializedName("options_limit")
+    private int optionsLimit;
+
+    @SerializedName("data")
+    private Map<String, Object> data;
+
+    /**
+     * @return the options
+     */
+    public List<FacetOptionConfiguration> getOptions() {
+        return options;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return the displayName
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * @return the sortOrder
+     */
+    public String getSortOrder() {
+        return sortOrder;
+    }
+
+    /**
+     * @return the sortDescending
+     */
+    public Boolean getSortDescending() {
+        return sortDescending;
+    }
+
+    /**
+     * @return the rangeType
+     */
+    public String getRangeType() {
+        return rangeType;
+    }
+
+    /**
+     * @return the rangeFormat
+     */
+    public String getRangeFormat() {
+        return rangeFormat;
+    }
+
+    /**
+     * @return the rangeInclusive
+     */
+    public String getRangeInclusive() {
+        return rangeInclusive;
+    }
+
+    /**
+     * @return the rangeLimits
+     */
+    public List<String> getRangeLimits() {
+        return rangeLimits;
+    }
+
+    /**
+     * @return the matchType
+     */
+    public MatchType getMatchType() {
+        return matchType;
+    }
+
+    /**
+     * @return the position
+     */
+    public int getPosition() {
+        return position;
+    }
+
+    /**
+     * @return the hidden
+     */
+    public Boolean getHidden() {
+        return hidden;
+    }
+
+    /**
+     * @return the isProtected
+     */
+    public Boolean getIsProtected() {
+        return isProtected;
+    }
+
+    /**
+     * @return the countable
+     */
+    public Boolean getCountable() {
+        return countable;
+    }
+
+    /**
+     * @return the optionsLimit
+     */
+    public int getOptionsLimit() {
+        return optionsLimit;
+    }
+
+    /**
+     * @return the data
+     */
+    public Map<String, Object> getData() {
+        return data;
+    }
+
+    public void setOptions(List<FacetOptionConfiguration> options) {
+        this.options = options;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public void setSortOrder(String sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public void setSortDescending(Boolean sortDescending) {
+        this.sortDescending = sortDescending;
+    }
+
+    public void setRangeType(String rangeType) {
+        this.rangeType = rangeType;
+    }
+
+    public void setRangeFormat(String rangeFormat) {
+        this.rangeFormat = rangeFormat;
+    }
+
+    public void setRangeInclusive(String rangeInclusive) {
+        this.rangeInclusive = rangeInclusive;
+    }
+
+    public void setRangeLimits(List<String> rangeLimits) {
+        this.rangeLimits = rangeLimits;
+    }
+
+    public void setMatchType(MatchType matchType) {
+        this.matchType = matchType;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public void setHidden(Boolean hidden) {
+        this.hidden = hidden;
+    }
+
+    public void setIsProtected(Boolean isProtected) {
+        this.isProtected = isProtected;
+    }
+
+    public void setCountable(Boolean countable) {
+        this.countable = countable;
+    }
+
+    public void setOptionsLimit(int optionsLimit) {
+        this.optionsLimit = optionsLimit;
+    }
+
+    public void setData(Map<String, Object> data) {
+        this.data = data;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/FacetOptionConfiguration.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/FacetOptionConfiguration.java
@@ -1,0 +1,105 @@
+package io.constructor.client.models;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.Map;
+
+/** Constructor.io Facet Option Configuration ... uses Gson/Reflection to load data in */
+public class FacetOptionConfiguration {
+
+    @SerializedName("value")
+    private String value;
+
+    @SerializedName("value_alias")
+    private String valueAlias;
+
+    @SerializedName("replace_value_alias")
+    private Boolean replaceValueAlias;
+
+    @SerializedName("display_name")
+    private String displayName;
+
+    @SerializedName("position")
+    private int position;
+
+    @SerializedName("data")
+    private Map<String, Object> data;
+
+    @SerializedName("hidden")
+    private Boolean hidden;
+
+    /**
+     * @return the value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * @return the valueAlias
+     */
+    public String getValueAlias() {
+        return valueAlias;
+    }
+
+    /**
+     * @return the replaceValueAlias
+     */
+    public Boolean getReplaceValueAlias() {
+        return replaceValueAlias;
+    }
+
+    /**
+     * @return the displayName
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * @return the position
+     */
+    public int getPosition() {
+        return position;
+    }
+
+    /**
+     * @return the data
+     */
+    public Map<String, Object> getData() {
+        return data;
+    }
+
+    /**
+     * @return the hidden
+     */
+    public Boolean getHidden() {
+        return hidden;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void setValueAlias(String valueAlias) {
+        this.valueAlias = valueAlias;
+    }
+
+    public void setReplaceValueAlias(Boolean replaceValueAlias) {
+        this.replaceValueAlias = replaceValueAlias;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public void setData(Map<String, Object> data) {
+        this.data = data;
+    }
+
+    public void setHidden(Boolean hidden) {
+        this.hidden = hidden;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/FacetOptionConfiguration.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/FacetOptionConfiguration.java
@@ -3,10 +3,7 @@ package io.constructor.client.models;
 import com.google.gson.annotations.SerializedName;
 import java.util.Map;
 
-/**
- * Constructor.io Facet Option Configuration ... uses Gson/Reflection to load
- * data in
- */
+/** Constructor.io Facet Option Configuration ... uses Gson/Reflection to load data in */
 public class FacetOptionConfiguration {
 
     @SerializedName("value")

--- a/constructorio-client/src/main/java/io/constructor/client/models/FacetOptionConfiguration.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/FacetOptionConfiguration.java
@@ -3,7 +3,10 @@ package io.constructor.client.models;
 import com.google.gson.annotations.SerializedName;
 import java.util.Map;
 
-/** Constructor.io Facet Option Configuration ... uses Gson/Reflection to load data in */
+/**
+ * Constructor.io Facet Option Configuration ... uses Gson/Reflection to load
+ * data in
+ */
 public class FacetOptionConfiguration {
 
     @SerializedName("value")
@@ -91,6 +94,7 @@ public class FacetOptionConfiguration {
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
     }
+
     public void setPosition(int position) {
         this.position = position;
     }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetConfigurationTest.java
@@ -1,0 +1,107 @@
+package io.constructor.client;
+
+import static org.junit.Assert.*;
+
+import io.constructor.client.models.FacetConfiguration;
+
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.gson.Gson;
+
+public class ConstructorIOFacetConfigurationTest {
+
+    private String token = System.getenv("TEST_API_TOKEN");
+    private String apiKey = System.getenv("TEST_CATALOG_API_KEY");
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void init() throws Exception {
+        // TODO: Add facet configuration cleanup after deleteFacetConfiguration function
+        // has been implemented
+    }
+
+    @After
+    public void teardown() throws Exception {
+        // TODO: Add facet configuration cleanup after deleteFacetConfiguration function
+        // has been implemented
+    }
+
+    @Test
+    public void CreateFacetConfigurationShouldReturn() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
+        String string = Utils.getTestResource("facet.configuration.json");
+        FacetConfiguration facetConfiguration = new Gson().fromJson(string, FacetConfiguration.class);
+
+        facetConfiguration.setName("testFacet");
+        FacetConfigurationRequest request = new FacetConfigurationRequest(facetConfiguration, "Products");
+
+        String response = constructor.createFacetConfiguration(request);
+        JSONObject jsonObj = new JSONObject(response);
+        JSONObject loadedJsonObj = new JSONObject(string);
+
+        assertEquals(jsonObj.get("name"), "testFacet");
+        assertEquals(jsonObj.get("type"), loadedJsonObj.get("type"));
+        assertEquals(jsonObj.get("display_name"), loadedJsonObj.get("display_name"));
+        assertEquals(jsonObj.get("sort_order"), loadedJsonObj.get("sort_order"));
+        assertEquals(jsonObj.get("sort_descending"), loadedJsonObj.get("sort_descending"));
+        assertEquals(jsonObj.get("match_type"), loadedJsonObj.get("match_type"));
+        assertEquals(jsonObj.get("position"), loadedJsonObj.get("position"));
+        assertEquals(jsonObj.get("hidden"), loadedJsonObj.get("hidden"));
+        assertEquals(jsonObj.get("protected"), loadedJsonObj.get("protected"));
+        assertEquals(jsonObj.get("countable"), loadedJsonObj.get("countable"));
+        assertEquals(jsonObj.get("options_limit"), loadedJsonObj.get("options_limit"));
+
+    }
+
+    @Test(expected = ConstructorException.class)
+    public void testCreateFacetConfigurationWithNullRequest() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
+
+        constructor.createFacetConfiguration(null);
+    }
+
+    @Test(expected = ConstructorException.class)
+    public void testCreateFacetConfigurationWithEmptySection() throws Exception {
+        ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
+        FacetConfiguration config = new FacetConfiguration();
+        config.setName("emptySection");
+        FacetConfigurationRequest request = new FacetConfigurationRequest(config,"");
+
+        constructor.createFacetConfiguration(request);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateFacetConfigurationWithNullConfiguration() throws
+    Exception {
+        ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
+
+    FacetConfigurationRequest request = new FacetConfigurationRequest(null,
+    "Products");
+
+    constructor.createFacetConfiguration(request);
+    }
+
+    @Test
+    public void testCreateFacetConfigurationWithDifferentSection() throws
+    Exception {
+        ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
+
+        String string = Utils.getTestResource("facet.configuration.json");
+        FacetConfiguration config = new Gson().fromJson(string, FacetConfiguration.class);
+
+    FacetConfigurationRequest request = new FacetConfigurationRequest(config,
+    "Search Suggestions");
+
+    String response = constructor.createFacetConfiguration(request);
+    JSONObject jsonObj = new JSONObject(response);
+
+    assertEquals("brand", jsonObj.getString("name"));
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetConfigurationTest.java
@@ -72,36 +72,34 @@ public class ConstructorIOFacetConfigurationTest {
         ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
         FacetConfiguration config = new FacetConfiguration();
         config.setName("emptySection");
-        FacetConfigurationRequest request = new FacetConfigurationRequest(config,"");
+        FacetConfigurationRequest request = new FacetConfigurationRequest(config, "");
 
         constructor.createFacetConfiguration(request);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testCreateFacetConfigurationWithNullConfiguration() throws
-    Exception {
+    public void testCreateFacetConfigurationWithNullConfiguration() throws Exception {
         ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
 
-    FacetConfigurationRequest request = new FacetConfigurationRequest(null,
-    "Products");
+        FacetConfigurationRequest request = new FacetConfigurationRequest(null,
+                "Products");
 
-    constructor.createFacetConfiguration(request);
+        constructor.createFacetConfiguration(request);
     }
 
     @Test
-    public void testCreateFacetConfigurationWithDifferentSection() throws
-    Exception {
+    public void testCreateFacetConfigurationWithDifferentSection() throws Exception {
         ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
 
         String string = Utils.getTestResource("facet.configuration.json");
         FacetConfiguration config = new Gson().fromJson(string, FacetConfiguration.class);
 
-    FacetConfigurationRequest request = new FacetConfigurationRequest(config,
-    "Search Suggestions");
+        FacetConfigurationRequest request = new FacetConfigurationRequest(config,
+                "Search Suggestions");
 
-    String response = constructor.createFacetConfiguration(request);
-    JSONObject jsonObj = new JSONObject(response);
+        String response = constructor.createFacetConfiguration(request);
+        JSONObject jsonObj = new JSONObject(response);
 
-    assertEquals("brand", jsonObj.getString("name"));
+        assertEquals("brand", jsonObj.getString("name"));
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetConfigurationTest.java
@@ -2,8 +2,8 @@ package io.constructor.client;
 
 import static org.junit.Assert.*;
 
+import com.google.gson.Gson;
 import io.constructor.client.models.FacetConfiguration;
-
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -11,15 +11,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.google.gson.Gson;
-
 public class ConstructorIOFacetConfigurationTest {
 
     private String token = System.getenv("TEST_API_TOKEN");
     private String apiKey = System.getenv("TEST_CATALOG_API_KEY");
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void init() throws Exception {
@@ -37,10 +34,12 @@ public class ConstructorIOFacetConfigurationTest {
     public void CreateFacetConfigurationShouldReturn() throws Exception {
         ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
         String string = Utils.getTestResource("facet.configuration.json");
-        FacetConfiguration facetConfiguration = new Gson().fromJson(string, FacetConfiguration.class);
+        FacetConfiguration facetConfiguration =
+                new Gson().fromJson(string, FacetConfiguration.class);
 
         facetConfiguration.setName("testFacet");
-        FacetConfigurationRequest request = new FacetConfigurationRequest(facetConfiguration, "Products");
+        FacetConfigurationRequest request =
+                new FacetConfigurationRequest(facetConfiguration, "Products");
 
         String response = constructor.createFacetConfiguration(request);
         JSONObject jsonObj = new JSONObject(response);
@@ -57,7 +56,6 @@ public class ConstructorIOFacetConfigurationTest {
         assertEquals(jsonObj.get("protected"), loadedJsonObj.get("protected"));
         assertEquals(jsonObj.get("countable"), loadedJsonObj.get("countable"));
         assertEquals(jsonObj.get("options_limit"), loadedJsonObj.get("options_limit"));
-
     }
 
     @Test(expected = ConstructorException.class)
@@ -81,8 +79,7 @@ public class ConstructorIOFacetConfigurationTest {
     public void testCreateFacetConfigurationWithNullConfiguration() throws Exception {
         ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
 
-        FacetConfigurationRequest request = new FacetConfigurationRequest(null,
-                "Products");
+        FacetConfigurationRequest request = new FacetConfigurationRequest(null, "Products");
 
         constructor.createFacetConfiguration(request);
     }
@@ -94,8 +91,8 @@ public class ConstructorIOFacetConfigurationTest {
         String string = Utils.getTestResource("facet.configuration.json");
         FacetConfiguration config = new Gson().fromJson(string, FacetConfiguration.class);
 
-        FacetConfigurationRequest request = new FacetConfigurationRequest(config,
-                "Search Suggestions");
+        FacetConfigurationRequest request =
+                new FacetConfigurationRequest(config, "Search Suggestions");
 
         String response = constructor.createFacetConfiguration(request);
         JSONObject jsonObj = new JSONObject(response);

--- a/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
@@ -3,15 +3,13 @@ package io.constructor.client;
 import static org.junit.Assert.assertEquals;
 
 import com.google.gson.Gson;
-
 import io.constructor.client.models.FacetConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class FacetConfigurationTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void multipleFacet() throws Exception {
@@ -43,6 +41,5 @@ public class FacetConfigurationTest {
         assertEquals(config.getRangeFormat(), "boundaries");
         assertEquals(config.getRangeInclusive(), "above");
         assertEquals(config.getRangeLimits().size(), 2);
-
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
@@ -9,9 +9,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-
 public class FacetConfigurationTest {
-    @Rule public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void multipleFacet() throws Exception {
@@ -43,6 +43,6 @@ public class FacetConfigurationTest {
         assertEquals(config.getRangeFormat(), "boundaries");
         assertEquals(config.getRangeInclusive(), "above");
         assertEquals(config.getRangeLimits().size(), 2);
-        
+
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
@@ -10,8 +10,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class FacetConfigurationTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void multipleFacet() throws Exception {

--- a/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
@@ -5,13 +5,13 @@ import static org.junit.Assert.assertEquals;
 import com.google.gson.Gson;
 import io.constructor.client.models.FacetConfiguration;
 import io.constructor.client.models.FacetConfiguration.MatchType;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class FacetConfigurationTest {
-    @Rule public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void multipleFacet() throws Exception {

--- a/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.gson.Gson;
 import io.constructor.client.models.FacetConfiguration;
+import io.constructor.client.models.FacetConfiguration.MatchType;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -21,7 +23,7 @@ public class FacetConfigurationTest {
         assertEquals(config.getType(), "multiple");
         assertEquals(config.getSortOrder(), "relevance");
         assertEquals(config.getSortDescending(), true);
-        assertEquals(config.getMatchType(), "any");
+        assertEquals(config.getMatchType(), MatchType.any);
         assertEquals(config.getPosition(), 2);
         assertEquals(config.getHidden(), false);
         assertEquals(config.getIsProtected(), false);

--- a/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FacetConfigurationTest.java
@@ -1,0 +1,48 @@
+package io.constructor.client;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.gson.Gson;
+
+import io.constructor.client.models.FacetConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+public class FacetConfigurationTest {
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void multipleFacet() throws Exception {
+        String string = Utils.getTestResource("facet.configuration.json");
+        FacetConfiguration config = new Gson().fromJson(string, FacetConfiguration.class);
+        assertEquals(config.getDisplayName(), "Brand");
+        assertEquals(config.getName(), "brand");
+        assertEquals(config.getOptions().size(), 1);
+        assertEquals(config.getType(), "multiple");
+        assertEquals(config.getSortOrder(), "relevance");
+        assertEquals(config.getSortDescending(), true);
+        assertEquals(config.getMatchType(), "any");
+        assertEquals(config.getPosition(), 2);
+        assertEquals(config.getHidden(), false);
+        assertEquals(config.getIsProtected(), false);
+        assertEquals(config.getCountable(), true);
+        assertEquals(config.getOptionsLimit(), 300);
+        assertEquals(config.getData().size(), 1);
+        assertEquals(config.getData().get("foo"), "bar");
+    }
+
+    @Test
+    public void rangeFacet() throws Exception {
+        String string = Utils.getTestResource("facet.range.configuration.json");
+        FacetConfiguration config = new Gson().fromJson(string, FacetConfiguration.class);
+        assertEquals(config.getName(), "price");
+        assertEquals(config.getType(), "range");
+        assertEquals(config.getRangeType(), "static");
+        assertEquals(config.getRangeFormat(), "boundaries");
+        assertEquals(config.getRangeInclusive(), "above");
+        assertEquals(config.getRangeLimits().size(), 2);
+        
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/FacetOptionConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FacetOptionConfigurationTest.java
@@ -9,9 +9,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-
 public class FacetOptionConfigurationTest {
-    @Rule public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void facetOption() throws Exception {

--- a/constructorio-client/src/test/java/io/constructor/client/FacetOptionConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FacetOptionConfigurationTest.java
@@ -1,0 +1,27 @@
+package io.constructor.client;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.gson.Gson;
+
+import io.constructor.client.models.FacetOptionConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+public class FacetOptionConfigurationTest {
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void facetOption() throws Exception {
+        String string = Utils.getTestResource("facet.option.configuration.json");
+        FacetOptionConfiguration config = new Gson().fromJson(string, FacetOptionConfiguration.class);
+        assertEquals(config.getDisplayName(), "Jif");
+        assertEquals(config.getValue(), "jif");
+        assertEquals(config.getReplaceValueAlias(), true);
+        assertEquals(config.getPosition(), 1);
+        assertEquals(config.getData().size(), 1);
+        assertEquals(config.getData().get("foo"), "bar");
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/FacetOptionConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FacetOptionConfigurationTest.java
@@ -3,20 +3,19 @@ package io.constructor.client;
 import static org.junit.Assert.assertEquals;
 
 import com.google.gson.Gson;
-
 import io.constructor.client.models.FacetOptionConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class FacetOptionConfigurationTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void facetOption() throws Exception {
         String string = Utils.getTestResource("facet.option.configuration.json");
-        FacetOptionConfiguration config = new Gson().fromJson(string, FacetOptionConfiguration.class);
+        FacetOptionConfiguration config =
+                new Gson().fromJson(string, FacetOptionConfiguration.class);
         assertEquals(config.getDisplayName(), "Jif");
         assertEquals(config.getValue(), "jif");
         assertEquals(config.getReplaceValueAlias(), true);

--- a/constructorio-client/src/test/resources/facet.configuration.json
+++ b/constructorio-client/src/test/resources/facet.configuration.json
@@ -1,0 +1,28 @@
+{
+    "options": [
+      {
+        "value": "jif",
+        "replace_value_alias": true,
+        "display_name": "Jif",
+        "position": 1,
+        "data": {
+            "foo": "bar"
+        },
+        "hidden": true
+      }
+    ],
+    "name": "brand",
+    "type": "multiple",
+    "display_name": "Brand",
+    "sort_order": "relevance",
+    "sort_descending": true,
+    "match_type": "any",
+    "position": 2,
+    "hidden": false,
+    "protected": false,
+    "countable": true,
+    "options_limit": 300,
+    "data": {
+        "foo": "bar"
+    }
+  }

--- a/constructorio-client/src/test/resources/facet.option.configuration.json
+++ b/constructorio-client/src/test/resources/facet.option.configuration.json
@@ -1,0 +1,9 @@
+{
+    "value": "jif",
+    "replace_value_alias": true,
+    "display_name": "Jif",
+    "position": 1,
+    "data": {
+        "foo": "bar"
+    }
+}

--- a/constructorio-client/src/test/resources/facet.range.configuration.json
+++ b/constructorio-client/src/test/resources/facet.range.configuration.json
@@ -1,0 +1,11 @@
+{
+    "name": "price",
+    "type": "range",
+    "range_type": "static",
+    "range_format": "boundaries",
+    "range_inclusive": "above",
+    "range_limits": [
+        5,
+        10
+    ]
+}


### PR DESCRIPTION
If you run test all together or run one two times, the test fails because the facet configuration already exists. Unfortunately, we need to delete the facet configuration until we add the `deleteFacetConfiguration` function. I left `TODO` comments where we would add cleanup when we add the delete function