### PR TITLE
[CI-2266] Add support for filtering on specific sections in Autocomplete Requests

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/AutocompleteRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/AutocompleteRequest.java
@@ -89,7 +89,6 @@ public class AutocompleteRequest {
         this.filtersPerSection = filtersPerSection;
     }
 
-
     /**
      * @return the filters
      */

--- a/constructorio-client/src/main/java/io/constructor/client/AutocompleteRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/AutocompleteRequest.java
@@ -13,6 +13,7 @@ public class AutocompleteRequest {
     private List<String> hiddenFields;
     private Map<String, List<String>> filters;
     private VariationsMap variationsMap;
+    private Map<String, Map<String, List<String>>> filtersPerSection;
 
     /**
      * Creates an autocomplete request
@@ -28,6 +29,7 @@ public class AutocompleteRequest {
         this.resultsPerSection = new HashMap<String, Integer>();
         this.hiddenFields = new ArrayList<String>();
         this.filters = new HashMap<String, List<String>>();
+        this.filtersPerSection = new HashMap<String, Map<String, List<String>>>();
         this.variationsMap = null;
     }
 
@@ -81,10 +83,25 @@ public class AutocompleteRequest {
     }
 
     /**
+     * @param filtersPerSection the filters to set
+     */
+    public void setFiltersPerSection(Map<String, Map<String, List<String>>> filtersPerSection) {
+        this.filtersPerSection = filtersPerSection;
+    }
+
+
+    /**
      * @return the filters
      */
     public Map<String, List<String>> getFilters() {
         return filters;
+    }
+
+    /**
+     * @return the filtersPerSection
+     */
+    public Map<String, Map<String, List<String>>> getFiltersPerSection() {
+        return filtersPerSection;
     }
 
     /**

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -879,10 +879,19 @@ public class ConstructorIO {
 
             for (String sectionName : req.getFiltersPerSection().keySet()) {
                 for (String filterName : req.getFiltersPerSection().get(sectionName).keySet()) {
-                    for (String facetValue : req.getFiltersPerSection().get(sectionName).get(filterName)) {
+                    for (String facetValue :
+                            req.getFiltersPerSection().get(sectionName).get(filterName)) {
                         url =
                                 url.newBuilder()
-                                        .addQueryParameter("filters" + "[" + sectionName + "]" + "[" + filterName + "]", facetValue)
+                                        .addQueryParameter(
+                                                "filters"
+                                                        + "["
+                                                        + sectionName
+                                                        + "]"
+                                                        + "["
+                                                        + filterName
+                                                        + "]",
+                                                facetValue)
                                         .build();
                     }
                 }

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -877,6 +877,17 @@ public class ConstructorIO {
                 }
             }
 
+            for (String sectionName : req.getFiltersPerSection().keySet()) {
+                for (String filterName : req.getFiltersPerSection().get(sectionName).keySet()) {
+                    for (String facetValue : req.getFiltersPerSection().get(sectionName).get(filterName)) {
+                        url =
+                                url.newBuilder()
+                                        .addQueryParameter("filters" + "[" + sectionName + "]" + "[" + filterName + "]", facetValue)
+                                        .build();
+                    }
+                }
+            }
+
             if (req.getVariationsMap() != null) {
                 String variationsMapJson = new Gson().toJson(req.getVariationsMap());
                 url =

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteTest.java
@@ -7,6 +7,9 @@ import com.google.gson.internal.LinkedTreeMap;
 import io.constructor.client.models.AutocompleteResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -187,6 +190,27 @@ public class ConstructorIOAutocompleteTest {
                 ((ArrayList) ((LinkedTreeMap) response.getRequest().get("filters")).get("group_id"))
                         .get(0),
                 "All");
+    }
+
+    @Test
+    public void autocompleteShouldReturnAResultWithSectionFilter() throws Exception {
+        ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
+        UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
+        AutocompleteRequest request = new AutocompleteRequest("item1");
+
+        Map<String, List<String>> filter = new HashMap<String, List<String>>();
+        filter.put("Brand", Arrays.asList("XYZ"));
+        request.getFiltersPerSection().put("Products", filter);
+
+        AutocompleteResponse response = constructor.autocomplete(request, userInfo);
+        LinkedTreeMap filters = (LinkedTreeMap)response.getRequest().get("filters");
+        LinkedTreeMap section = (LinkedTreeMap)filters.get("Products");
+        ArrayList filterValues = (ArrayList)section.get("Brand");
+
+        assertEquals(
+        "autocomplete request [Products][Brand] filter should match",
+        filterValues.get(0),
+        "XYZ");
     }
 
     @Test

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteTest.java
@@ -203,14 +203,14 @@ public class ConstructorIOAutocompleteTest {
         request.getFiltersPerSection().put("Products", filter);
 
         AutocompleteResponse response = constructor.autocomplete(request, userInfo);
-        LinkedTreeMap filters = (LinkedTreeMap)response.getRequest().get("filters");
-        LinkedTreeMap section = (LinkedTreeMap)filters.get("Products");
-        ArrayList filterValues = (ArrayList)section.get("Brand");
+        LinkedTreeMap filters = (LinkedTreeMap) response.getRequest().get("filters");
+        LinkedTreeMap section = (LinkedTreeMap) filters.get("Products");
+        ArrayList filterValues = (ArrayList) section.get("Brand");
 
         assertEquals(
-        "autocomplete request [Products][Brand] filter should match",
-        filterValues.get(0),
-        "XYZ");
+                "autocomplete request [Products][Brand] filter should match",
+                filterValues.get(0),
+                "XYZ");
     }
 
     @Test


### PR DESCRIPTION
Add `filtersPerSection` parameter to autocomplete request object and build request URL with section added to filters