### PR TITLE
[CI-4518] Expose `is_slotted` in Search/Browse API Responses

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/models/Result.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Result.java
@@ -22,6 +22,9 @@ public class Result {
     @SerializedName("variations_map")
     private Object variationsMap;
 
+    @SerializedName("is_slotted")
+    private boolean isSlotted;
+
     @SerializedName("labels")
     private Map<String, Object> labels;
 
@@ -77,6 +80,13 @@ public class Result {
         return strategy;
     }
 
+    /**
+     * @return isSlotted boolean
+     */
+    public boolean getIsSlotted() {
+        return isSlotted;
+    }
+
     public void setValue(String value) {
         this.value = value;
     }
@@ -103,5 +113,9 @@ public class Result {
 
     public void setStrategy(Map<String, String> strategy) {
         this.strategy = strategy;
+    }
+
+    public void setIsBoolean(boolean isSlotted) {
+        this.isSlotted = isSlotted;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/Result.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Result.java
@@ -115,7 +115,7 @@ public class Result {
         this.strategy = strategy;
     }
 
-    public void setIsBoolean(boolean isSlotted) {
+    public void setIsSlotted(boolean isSlotted) {
         this.isSlotted = isSlotted;
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/BrowseResponseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/BrowseResponseTest.java
@@ -286,4 +286,18 @@ public class BrowseResponseTest {
                         .get("display_name"),
                 "New Arrival");
     }
+
+    @Test
+    public void createBrowseResponseShouldReturnAResultWithIsSlotted() throws Exception {
+        String string = Utils.getTestResource("response.browse.color.blue.json");
+        BrowseResponse response = ConstructorIO.createBrowseResponse(string);
+        assertEquals(
+                "search result [labels] exists",
+                response.getResponse().getResults().get(0).getIsSlotted(),
+                true);
+        assertEquals(
+                "search result [labels] exists",
+                response.getResponse().getResults().get(1).getIsSlotted(),
+                false);
+    }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteTest.java
@@ -224,7 +224,8 @@ public class ConstructorIOAutocompleteTest {
         variationsMap.addValueRule(
                 "size", VariationsMap.AggregationTypes.first, "data.facets.size");
         variationsMap.setFilterBy(
-                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"type\":\"single\",\"value\":\"Best Brand\"},\"type\":\"not\"}],\"type\":\"and\"}");
+                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"type\":\"single\",\"value\":\"Best"
+                        + " Brand\"},\"type\":\"not\"}],\"type\":\"and\"}");
         request.setVariationsMap(variationsMap);
         AutocompleteResponse response = constructor.autocomplete(request, userInfo);
 

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteTest.java
@@ -171,7 +171,7 @@ public class ConstructorIOAutocompleteTest {
     public void autocompleteShouldReturnAResultWithMultipleFilters() throws Exception {
         ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
-        AutocompleteRequest request = new AutocompleteRequest("item1");
+        AutocompleteRequest request = new AutocompleteRequest("item2");
         request.getFilters().put("group_id", Arrays.asList("All"));
         request.getFilters().put("Brand", Arrays.asList("XYZ"));
         AutocompleteResponse response = constructor.autocomplete(request, userInfo);
@@ -224,7 +224,7 @@ public class ConstructorIOAutocompleteTest {
         variationsMap.addValueRule(
                 "size", VariationsMap.AggregationTypes.first, "data.facets.size");
         variationsMap.setFilterBy(
-                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"value\":\"Best Brand\"}}]}");
+                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"type\":\"single\",\"value\":\"Best Brand\"},\"type\":\"not\"}],\"type\":\"and\"}");
         request.setVariationsMap(variationsMap);
         AutocompleteResponse response = constructor.autocomplete(request, userInfo);
 

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -368,7 +368,7 @@ public class ConstructorIOBrowseTest {
         variationsMap.addValueRule(
                 "size", VariationsMap.AggregationTypes.first, "data.facets.size");
         variationsMap.setFilterBy(
-                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"value\":\"Best Brand\"}}]}");
+                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"type\":\"single\",\"value\":\"Best Brand\"},\"type\":\"not\"}],\"type\":\"and\"}");
         request.setVariationsMap(variationsMap);
         BrowseResponse response = constructor.browse(request, userInfo);
 

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -368,7 +368,8 @@ public class ConstructorIOBrowseTest {
         variationsMap.addValueRule(
                 "size", VariationsMap.AggregationTypes.first, "data.facets.size");
         variationsMap.setFilterBy(
-                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"type\":\"single\",\"value\":\"Best Brand\"},\"type\":\"not\"}],\"type\":\"and\"}");
+                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"type\":\"single\",\"value\":\"Best"
+                        + " Brand\"},\"type\":\"not\"}],\"type\":\"and\"}");
         request.setVariationsMap(variationsMap);
         BrowseResponse response = constructor.browse(request, userInfo);
 

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -100,8 +100,8 @@ public class ConstructorIOSearchTest {
     public void SearchShouldReturnAResultWithColorFacets() throws Exception {
         ConstructorIO constructor = new ConstructorIO("", apiKey, true, null);
         UserInfo userInfo = new UserInfo(3, "c62a-2a09-faie");
-        SearchRequest request = new SearchRequest("item1");
-        request.getFacets().put("Color", Arrays.asList("Blue"));
+        SearchRequest request = new SearchRequest("item2");
+        request.getFacets().put("Color", Arrays.asList("yellow"));
         SearchResponse response = constructor.search(request, userInfo);
         assertEquals("search results exist", response.getResponse().getResults().size(), 1);
         assertEquals(
@@ -359,7 +359,7 @@ public class ConstructorIOSearchTest {
         variationsMap.addValueRule(
                 "size", VariationsMap.AggregationTypes.first, "data.facets.size");
         variationsMap.setFilterBy(
-                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"value\":\"Best Brand\"}}]}");
+                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"type\":\"single\",\"value\":\"Best Brand\"},\"type\":\"not\"}],\"type\":\"and\"}");
         System.out.println(variationsMap.getFilterBy());
         request.setVariationsMap(variationsMap);
         SearchResponse response = constructor.search(request, userInfo);

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchTest.java
@@ -359,7 +359,8 @@ public class ConstructorIOSearchTest {
         variationsMap.addValueRule(
                 "size", VariationsMap.AggregationTypes.first, "data.facets.size");
         variationsMap.setFilterBy(
-                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"type\":\"single\",\"value\":\"Best Brand\"},\"type\":\"not\"}],\"type\":\"and\"}");
+                "{\"and\":[{\"not\":{\"field\":\"data.brand\",\"type\":\"single\",\"value\":\"Best"
+                        + " Brand\"},\"type\":\"not\"}],\"type\":\"and\"}");
         System.out.println(variationsMap.getFilterBy());
         request.setVariationsMap(variationsMap);
         SearchResponse response = constructor.search(request, userInfo);

--- a/constructorio-client/src/test/java/io/constructor/client/FiltersTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/FiltersTest.java
@@ -65,7 +65,7 @@ public class FiltersTest {
         assertEquals(facet.getName(), "Size");
         assertEquals(facet.getType(), "hierarchical");
         assertEquals(facet.getOptions().get(0).getValue(), "Mens");
-        assertEquals(facet.getOptions().get(0).getOptions().get(0), "Mens/Small");
+        assertEquals(facet.getOptions().get(0).getOptions().get(0).getValue(), "Mens/Small");
         assertNull(facet.getMax());
         assertNull(facet.getMin());
         assertNull(facet.getStatus());

--- a/constructorio-client/src/test/java/io/constructor/client/SearchResponseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/SearchResponseTest.java
@@ -262,4 +262,18 @@ public class SearchResponseTest {
                         .get("display_name"),
                 "New Arrival");
     }
+
+    @Test
+    public void createSearchResponseShouldReturnAResultWithIsSlotted() throws Exception {
+        String string = Utils.getTestResource("response.search.item.json");
+        SearchResponse response = ConstructorIO.createSearchResponse(string);
+        assertEquals(
+                "search result [isSlotted] exists",
+                response.getResponse().getResults().get(0).getIsSlotted(),
+                true);
+        assertEquals(
+                "search result [isSlotted] exists",
+                response.getResponse().getResults().get(1).getIsSlotted(),
+                false);
+    }
 }

--- a/constructorio-client/src/test/resources/response.browse.color.blue.json
+++ b/constructorio-client/src/test/resources/response.browse.color.blue.json
@@ -1051,7 +1051,7 @@
         "url": "https://demo.commercetools.com/en/aspesi-coat-I502997385098-blue.html",
         "variation_id": "M0E20000000ECTT"
       },
-      "is_slotted": false,
+      "is_slotted": true,
       "matched_terms": [],
       "value": "Coat Aspesi blue",
       "variations": [{


### PR DESCRIPTION
- Adds new field `isSlotted` to `Result` class that is serialized from `is_slotted` from the API responses.
- Also fixes some tests that were breaking due to our test catalog changing

> Note: There are a couple of breaking tests in the `ConstructorIOTasksTest.java`. This is unrelated to this PR and is due to how we're picking the timeframe to test. Will fix in a separate PR
