### PR TITLE
Update facet configuration `position` and `optionsLimit` parameters

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/models/FacetConfiguration.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/FacetConfiguration.java
@@ -46,7 +46,7 @@ public class FacetConfiguration {
     private MatchType matchType;
 
     @SerializedName("position")
-    private int position;
+    private Integer position;
 
     @SerializedName("hidden")
     private Boolean hidden;
@@ -58,7 +58,7 @@ public class FacetConfiguration {
     private Boolean countable;
 
     @SerializedName("options_limit")
-    private int optionsLimit;
+    private Integer optionsLimit;
 
     @SerializedName("data")
     private Map<String, Object> data;
@@ -143,7 +143,7 @@ public class FacetConfiguration {
     /**
      * @return the position
      */
-    public int getPosition() {
+    public Integer getPosition() {
         return position;
     }
 
@@ -171,7 +171,7 @@ public class FacetConfiguration {
     /**
      * @return the optionsLimit
      */
-    public int getOptionsLimit() {
+    public Integer getOptionsLimit() {
         return optionsLimit;
     }
 
@@ -226,7 +226,7 @@ public class FacetConfiguration {
         this.matchType = matchType;
     }
 
-    public void setPosition(int position) {
+    public void setPosition(Integer position) {
         this.position = position;
     }
 
@@ -242,7 +242,7 @@ public class FacetConfiguration {
         this.countable = countable;
     }
 
-    public void setOptionsLimit(int optionsLimit) {
+    public void setOptionsLimit(Integer optionsLimit) {
         this.optionsLimit = optionsLimit;
     }
 

--- a/constructorio-client/src/main/java/io/constructor/client/models/FacetOptionConfiguration.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/FacetOptionConfiguration.java
@@ -19,7 +19,7 @@ public class FacetOptionConfiguration {
     private String displayName;
 
     @SerializedName("position")
-    private int position;
+    private Integer position;
 
     @SerializedName("data")
     private Map<String, Object> data;
@@ -58,7 +58,7 @@ public class FacetOptionConfiguration {
     /**
      * @return the position
      */
-    public int getPosition() {
+    public Integer getPosition() {
         return position;
     }
 
@@ -92,7 +92,7 @@ public class FacetOptionConfiguration {
         this.displayName = displayName;
     }
 
-    public void setPosition(int position) {
+    public void setPosition(Integer position) {
         this.position = position;
     }
 

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetConfigurationTest.java
@@ -186,4 +186,11 @@ public class ConstructorIOFacetConfigurationTest {
         ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
         constructor.deleteFacetConfiguration("nonExistentFacet", "Products");
     }
+
+    @Test
+    public void testFacetConfigurationDefaultValues() {
+        FacetConfiguration config = new FacetConfiguration();
+        assertNull("Position should default to null", config.getPosition());
+        assertNull("Options limit should default to null", config.getOptionsLimit());
+    }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetOptionConfigurationTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOFacetOptionConfigurationTest.java
@@ -72,7 +72,7 @@ public class ConstructorIOFacetOptionConfigurationTest {
     }
 
     private FacetOptionConfiguration createFacetOptionConfigurationObject(
-            String value, String displayName, int position) {
+            String value, String displayName, Integer position) {
         FacetOptionConfiguration config = new FacetOptionConfiguration();
         config.setValue(value);
         config.setDisplayName(displayName);
@@ -136,7 +136,7 @@ public class ConstructorIOFacetOptionConfigurationTest {
         assertEquals("test-option", jsonObj.get("value"));
         assertEquals("test-alias", jsonObj.get("value_alias"));
         assertEquals("Test Option", jsonObj.get("display_name"));
-        assertEquals(1, jsonObj.get("position"));
+        assertEquals(1, jsonObj.getInt("position"));
         assertEquals(false, jsonObj.get("hidden"));
         assertEquals("bar", jsonObj.getJSONObject("data").get("foo"));
 
@@ -269,5 +269,11 @@ public class ConstructorIOFacetOptionConfigurationTest {
     public void testDeleteNonExistentFacetOptionShouldThrowException() throws Exception {
         constructor.deleteFacetOptionConfiguration(
                 "nonExistentFacet", "nonExistentOption", PRODUCTS_SECTION);
+    }
+
+    @Test
+    public void testFacetOptionConfigurationDefaultValues() {
+        FacetOptionConfiguration config = new FacetOptionConfiguration();
+        assertNull("Position should default to null", config.getPosition());
     }
 }


### PR DESCRIPTION
# Issue
- `position` and `options_limit` default to zero due to type `int`

# Fix
- Change type from `int` to `Integer` which will default the values to null instead of zero
- Add tests
