### PR TITLE
[CDX-255] Expose features object in request models

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/models/BrowseResponseInner.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/BrowseResponseInner.java
@@ -12,6 +12,9 @@ public class BrowseResponseInner extends BaseResultsResponse {
     @SerializedName("refined_content")
     private List<RefinedContent> refinedContent;
 
+    @SerializedName("features")
+    private List<Feature> features;
+
     /**
      * @return the item collection data
      */
@@ -26,11 +29,22 @@ public class BrowseResponseInner extends BaseResultsResponse {
         return refinedContent;
     }
 
+    /**
+     * @return features list
+     */
+    public List<Feature> getFeatures() {
+        return features;
+    }
+
     public void setCollection(ItemCollection collection) {
         this.collection = collection;
     }
 
     public void setRefinedContent(List<RefinedContent> refinedContent) {
         this.refinedContent = refinedContent;
+    }
+
+    public void setFeatures(List<Feature> features) {
+        this.features = features;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/Feature.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Feature.java
@@ -1,0 +1,62 @@
+package io.constructor.client.models;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Feature {
+
+    @SerializedName("display_name")
+    private String displayName;
+    
+    @SerializedName("feature_name")
+    private String featureName;
+
+    @SerializedName("enabled")
+    private Boolean enabled;
+
+    @SerializedName("variant")
+    private Variant variant;
+
+    /**
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * @return the feature name
+     */
+    public String getFeatureName() {
+        return featureName;
+    }
+
+    /**
+     * @return enabled
+     */
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    /**
+     * @return the variant
+     */
+    public Variant getVariant() {
+        return variant;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public void setFeatureName(String featureName) {
+        this.featureName = featureName;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setVariant(Variant variant) {
+        this.variant = variant;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/SearchResponseInner.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/SearchResponseInner.java
@@ -12,6 +12,9 @@ public class SearchResponseInner extends BaseResultsResponse {
     @SerializedName("refined_content")
     private List<RefinedContent> refinedContent;
 
+    @SerializedName("features")
+    private List<Feature> features;
+
     /**
      * @return redirect data
      */
@@ -26,11 +29,22 @@ public class SearchResponseInner extends BaseResultsResponse {
         return refinedContent;
     }
 
+    /**
+     * @return features list
+     */
+    public List<Feature> getFeatures() {
+        return features;
+    }
+
     public void setRedirect(Redirect redirect) {
         this.redirect = redirect;
     }
 
     public void setRefinedContent(List<RefinedContent> refinedContent) {
         this.refinedContent = refinedContent;
+    }
+
+    public void setFeatures(List<Feature> features) {
+        this.features = features;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/Variant.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/Variant.java
@@ -1,0 +1,34 @@
+package io.constructor.client.models;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Variant {
+
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("display_name")
+    private String displayName;
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the display name
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/constructorio-client/src/test/java/io/constructor/client/BrowseResponseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/BrowseResponseTest.java
@@ -17,6 +17,8 @@ public class BrowseResponseTest {
     public void createBrowseResponseShouldReturnAResult() throws Exception {
         String string = Utils.getTestResource("response.browse.color.blue.json");
         BrowseResponse response = ConstructorIO.createBrowseResponse(string);
+        Map<String, Object> features = (Map<String, Object>) response.getRequest().get("features");
+        System.out.println(features.get("personalization"));
         assertEquals("browse facets exist", response.getResponse().getFacets().size(), 7);
         assertEquals(
                 "browse facet [Brand] exists",
@@ -299,5 +301,35 @@ public class BrowseResponseTest {
                 "search result [labels] exists",
                 response.getResponse().getResults().get(1).getIsSlotted(),
                 false);
+    }
+
+    @Test
+    public void createBrowseResponseShouldReturnAResultWithFeatures() throws Exception {
+        String string = Utils.getTestResource("response.browse.color.blue.json");
+        BrowseResponse response = ConstructorIO.createBrowseResponse(string);
+        assertEquals(
+                "browse result [features] exists",
+                response.getResponse().getFeatures().size(),
+                5);
+        assertEquals(
+                "browse result feature [feature name] exists",
+                response.getResponse().getFeatures().get(0).getFeatureName(),
+                "auto_generated_refined_query_rules");
+        assertEquals(
+                "browse result feature [display name] exists",
+                response.getResponse().getFeatures().get(0).getDisplayName(),
+                "Affinity Engine");
+        assertEquals(
+                "browse result feature [enabled] exists",
+                response.getResponse().getFeatures().get(0).getEnabled(),
+                true);
+        assertEquals(
+                "browse result feature variant [display name] exists",
+                response.getResponse().getFeatures().get(0).getVariant().getDisplayName(),
+                "Default weights");
+        assertEquals(
+                "browse result feature variant [name] exists",
+                response.getResponse().getFeatures().get(0).getVariant().getName(),
+                "default_rules");
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/BrowseResponseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/BrowseResponseTest.java
@@ -17,8 +17,6 @@ public class BrowseResponseTest {
     public void createBrowseResponseShouldReturnAResult() throws Exception {
         String string = Utils.getTestResource("response.browse.color.blue.json");
         BrowseResponse response = ConstructorIO.createBrowseResponse(string);
-        Map<String, Object> features = (Map<String, Object>) response.getRequest().get("features");
-        System.out.println(features.get("personalization"));
         assertEquals("browse facets exist", response.getResponse().getFacets().size(), 7);
         assertEquals(
                 "browse facet [Brand] exists",

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -606,6 +606,8 @@ public class ConstructorIOBrowseTest {
         BrowseRequest request = new BrowseRequest("group_id", "BrandA");
         BrowseResponse response = constructor.browse(request, userInfo);
 
+        System.out.println(response.getRequest().get("features"));
+
         List<Result> resultsList = response.getResponse().getResults();
         assertTrue("search results exist", resultsList.size() > 0);
 

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOBrowseTest.java
@@ -606,8 +606,6 @@ public class ConstructorIOBrowseTest {
         BrowseRequest request = new BrowseRequest("group_id", "BrandA");
         BrowseResponse response = constructor.browse(request, userInfo);
 
-        System.out.println(response.getRequest().get("features"));
-
         List<Result> resultsList = response.getResponse().getResults();
         assertTrue("search results exist", resultsList.size() > 0);
 

--- a/constructorio-client/src/test/java/io/constructor/client/SearchResponseTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/SearchResponseTest.java
@@ -276,4 +276,34 @@ public class SearchResponseTest {
                 response.getResponse().getResults().get(1).getIsSlotted(),
                 false);
     }
+
+    @Test
+    public void createSearchResponseShouldReturnAResultWithFeatures() throws Exception {
+        String string = Utils.getTestResource("response.search.item.json");
+        SearchResponse response = ConstructorIO.createSearchResponse(string);
+        assertEquals(
+                "search result [features] exists",
+                response.getResponse().getFeatures().size(),
+                5);
+        assertEquals(
+                "search result feature [feature name] exists",
+                response.getResponse().getFeatures().get(0).getFeatureName(),
+                "auto_generated_refined_query_rules");
+        assertEquals(
+                "search result feature [display name] exists",
+                response.getResponse().getFeatures().get(0).getDisplayName(),
+                "Affinity Engine");
+        assertEquals(
+                "search result feature [enabled] exists",
+                response.getResponse().getFeatures().get(0).getEnabled(),
+                true);
+        assertEquals(
+                "search result feature variant [name] exists",
+                response.getResponse().getFeatures().get(0).getVariant().getName(),
+                "default_rules");
+        assertEquals(
+                "search result feature variant [display name] exists",
+                response.getResponse().getFeatures().get(0).getVariant().getDisplayName(),
+                "Default weights");
+    }
 }


### PR DESCRIPTION
- Add features to Search and Browse response models
- Add tests
- `features` & `feature_variants` that are inside the `request` object of the response can be accessed as the `request` object is a generic `Map<String, Object>`
  - Ex: `Map<String, Object> features = (Map<String, Object>) response.getRequest().get("features");`
        `System.out.println(features.get("personalization"));`