### PR TITLE
[CDX-480] Expose headers for Autocomplete and Search Responses

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorException.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorException.java
@@ -1,7 +1,12 @@
 package io.constructor.client;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 public class ConstructorException extends Exception {
     private Integer errorCode;
+    private Map<String, List<String>> headers = Collections.<String, List<String>>emptyMap();
 
     public ConstructorException(String msg) {
         super(msg);
@@ -11,6 +16,7 @@ public class ConstructorException extends Exception {
         super(e);
         if (e instanceof ConstructorException) {
             this.errorCode = ((ConstructorException) e).getErrorCode();
+            this.headers = ((ConstructorException) e).getHeaders();
         }
     }
 
@@ -21,5 +27,19 @@ public class ConstructorException extends Exception {
 
     public Integer getErrorCode() {
         return this.errorCode;
+    }
+
+    /**
+     * @return the HTTP response headers, or an empty map if not available
+     */
+    public Map<String, List<String>> getHeaders() {
+        return this.headers;
+    }
+
+    /**
+     * @param headers the HTTP response headers to set. If null, defaults to an empty map.
+     */
+    public void setHeaders(Map<String, List<String>> headers) {
+        this.headers = (headers != null) ? headers : Collections.<String, List<String>>emptyMap();
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -925,14 +925,17 @@ public class ConstructorIO {
      */
     public AutocompleteResponse autocomplete(AutocompleteRequest req, UserInfo userInfo)
             throws ConstructorException {
+        Map<String, List<String>> headers = null;
         try {
             Request request = createAutocompleteRequest(req, userInfo);
             Response response = clientWithRetry.newCall(request).execute();
-            Map<String, List<String>> headers = response.headers().toMultimap();
+            headers = response.headers().toMultimap();
             String json = getResponseBody(response);
             return createAutocompleteResponse(json, headers);
         } catch (Exception exception) {
-            throw new ConstructorException(exception);
+            ConstructorException ce = new ConstructorException(exception);
+            ce.setHeaders(headers);
+            throw ce;
         }
     }
 
@@ -1187,14 +1190,17 @@ public class ConstructorIO {
      * @throws ConstructorException if the request is invalid.
      */
     public SearchResponse search(SearchRequest req, UserInfo userInfo) throws ConstructorException {
+        Map<String, List<String>> headers = null;
         try {
             Request request = createSearchRequest(req, userInfo);
             Response response = clientWithRetry.newCall(request).execute();
-            Map<String, List<String>> headers = response.headers().toMultimap();
+            headers = response.headers().toMultimap();
             String json = getResponseBody(response);
             return createSearchResponse(json, headers);
         } catch (Exception exception) {
-            throw new ConstructorException(exception);
+            ConstructorException ce = new ConstructorException(exception);
+            ce.setHeaders(headers);
+            throw ce;
         }
     }
 
@@ -1226,14 +1232,16 @@ public class ConstructorIO {
                                 @Override
                                 public void onResponse(Call call, final Response response)
                                         throws IOException {
+                                    Map<String, List<String>> headers = null;
                                     try {
-                                        Map<String, List<String>> headers =
-                                                response.headers().toMultimap();
+                                        headers = response.headers().toMultimap();
                                         String json = getResponseBody(response);
                                         SearchResponse res = createSearchResponse(json, headers);
                                         c.onResponse(res);
                                     } catch (Exception e) {
-                                        c.onFailure(new ConstructorException(e));
+                                        ConstructorException ce = new ConstructorException(e);
+                                        ce.setHeaders(headers);
+                                        c.onFailure(ce);
                                     }
                                 }
                             });

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -1227,8 +1227,10 @@ public class ConstructorIO {
                                 public void onResponse(Call call, final Response response)
                                         throws IOException {
                                     try {
+                                        Map<String, List<String>> headers =
+                                                response.headers().toMultimap();
                                         String json = getResponseBody(response);
-                                        SearchResponse res = createSearchResponse(json);
+                                        SearchResponse res = createSearchResponse(json, headers);
                                         c.onResponse(res);
                                     } catch (Exception e) {
                                         c.onFailure(new ConstructorException(e));

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -926,8 +926,11 @@ public class ConstructorIO {
     public AutocompleteResponse autocomplete(AutocompleteRequest req, UserInfo userInfo)
             throws ConstructorException {
         try {
-            String json = autocompleteAsJSON(req, userInfo);
-            return createAutocompleteResponse(json);
+            Request request = createAutocompleteRequest(req, userInfo);
+            Response response = clientWithRetry.newCall(request).execute();
+            Map<String, List<String>> headers = response.headers().toMultimap();
+            String json = getResponseBody(response);
+            return createAutocompleteResponse(json, headers);
         } catch (Exception exception) {
             throw new ConstructorException(exception);
         }
@@ -948,74 +951,83 @@ public class ConstructorIO {
     public String autocompleteAsJSON(AutocompleteRequest req, UserInfo userInfo)
             throws ConstructorException {
         try {
-            List<String> paths = Arrays.asList("autocomplete", req.getQuery());
-            HttpUrl url = (userInfo == null) ? this.makeUrl(paths) : this.makeUrl(paths, userInfo);
-
-            for (Map.Entry<String, Integer> entry : req.getResultsPerSection().entrySet()) {
-                String section = entry.getKey();
-                String count = String.valueOf(entry.getValue());
-                url = url.newBuilder().addQueryParameter("num_results_" + section, count).build();
-            }
-
-            for (String hiddenField : req.getHiddenFields()) {
-                url =
-                        url.newBuilder()
-                                .addQueryParameter("fmt_options[hidden_fields]", hiddenField)
-                                .build();
-            }
-
-            for (String filterName : req.getFilters().keySet()) {
-                for (String facetValue : req.getFilters().get(filterName)) {
-                    url =
-                            url.newBuilder()
-                                    .addQueryParameter("filters[" + filterName + "]", facetValue)
-                                    .build();
-                }
-            }
-
-            for (String sectionName : req.getFiltersPerSection().keySet()) {
-                for (String filterName : req.getFiltersPerSection().get(sectionName).keySet()) {
-                    for (String facetValue :
-                            req.getFiltersPerSection().get(sectionName).get(filterName)) {
-                        url =
-                                url.newBuilder()
-                                        .addQueryParameter(
-                                                "filters"
-                                                        + "["
-                                                        + sectionName
-                                                        + "]"
-                                                        + "["
-                                                        + filterName
-                                                        + "]",
-                                                facetValue)
-                                        .build();
-                    }
-                }
-            }
-
-            if (req.getVariationsMap() != null) {
-                String variationsMapJson = new Gson().toJson(req.getVariationsMap());
-                url =
-                        url.newBuilder()
-                                .addQueryParameter("variations_map", variationsMapJson)
-                                .build();
-            }
-
-            if (req.getPreFilterExpression() != null) {
-                url =
-                        url.newBuilder()
-                                .addQueryParameter(
-                                        "pre_filter_expression", req.getPreFilterExpression())
-                                .build();
-            }
-
-            Request request = this.makeUserRequestBuilder(userInfo).url(url).get().build();
-
+            Request request = createAutocompleteRequest(req, userInfo);
             Response response = clientWithRetry.newCall(request).execute();
             return getResponseBody(response);
         } catch (Exception exception) {
             throw new ConstructorException(exception);
         }
+    }
+
+    /**
+     * Creates an autocomplete OkHttp request
+     *
+     * @param req the autocomplete request
+     * @param userInfo optional information about the user
+     * @return an autocomplete OkHttp request
+     * @throws ConstructorException
+     */
+    protected Request createAutocompleteRequest(AutocompleteRequest req, UserInfo userInfo)
+            throws ConstructorException, UnsupportedEncodingException {
+        List<String> paths = Arrays.asList("autocomplete", req.getQuery());
+        HttpUrl url = (userInfo == null) ? this.makeUrl(paths) : this.makeUrl(paths, userInfo);
+
+        for (Map.Entry<String, Integer> entry : req.getResultsPerSection().entrySet()) {
+            String section = entry.getKey();
+            String count = String.valueOf(entry.getValue());
+            url = url.newBuilder().addQueryParameter("num_results_" + section, count).build();
+        }
+
+        for (String hiddenField : req.getHiddenFields()) {
+            url =
+                    url.newBuilder()
+                            .addQueryParameter("fmt_options[hidden_fields]", hiddenField)
+                            .build();
+        }
+
+        for (String filterName : req.getFilters().keySet()) {
+            for (String facetValue : req.getFilters().get(filterName)) {
+                url =
+                        url.newBuilder()
+                                .addQueryParameter("filters[" + filterName + "]", facetValue)
+                                .build();
+            }
+        }
+
+        for (String sectionName : req.getFiltersPerSection().keySet()) {
+            for (String filterName : req.getFiltersPerSection().get(sectionName).keySet()) {
+                for (String facetValue :
+                        req.getFiltersPerSection().get(sectionName).get(filterName)) {
+                    url =
+                            url.newBuilder()
+                                    .addQueryParameter(
+                                            "filters"
+                                                    + "["
+                                                    + sectionName
+                                                    + "]"
+                                                    + "["
+                                                    + filterName
+                                                    + "]",
+                                            facetValue)
+                                    .build();
+                }
+            }
+        }
+
+        if (req.getVariationsMap() != null) {
+            String variationsMapJson = new Gson().toJson(req.getVariationsMap());
+            url = url.newBuilder().addQueryParameter("variations_map", variationsMapJson).build();
+        }
+
+        if (req.getPreFilterExpression() != null) {
+            url =
+                    url.newBuilder()
+                            .addQueryParameter(
+                                    "pre_filter_expression", req.getPreFilterExpression())
+                            .build();
+        }
+
+        return this.makeUserRequestBuilder(userInfo).url(url).get().build();
     }
 
     /**
@@ -1171,8 +1183,9 @@ public class ConstructorIO {
         try {
             Request request = createSearchRequest(req, userInfo);
             Response response = clientWithRetry.newCall(request).execute();
+            Map<String, List<String>> headers = response.headers().toMultimap();
             String json = getResponseBody(response);
-            return createSearchResponse(json);
+            return createSearchResponse(json, headers);
         } catch (Exception exception) {
             throw new ConstructorException(exception);
         }
@@ -2200,6 +2213,11 @@ public class ConstructorIO {
      * to do it in a Gson Type Adapter.
      */
     protected static AutocompleteResponse createAutocompleteResponse(String string) {
+        return createAutocompleteResponse(string, null);
+    }
+
+    protected static AutocompleteResponse createAutocompleteResponse(
+            String string, Map<String, List<String>> headers) {
         JSONObject json = new JSONObject(string);
         JSONObject sections = json.getJSONObject("sections");
         for (Object sectionKey : sections.keySet()) {
@@ -2208,7 +2226,11 @@ public class ConstructorIO {
             moveMetadataOutOfResultData(results);
         }
         String transformed = json.toString();
-        return new Gson().fromJson(transformed, AutocompleteResponse.class);
+        AutocompleteResponse autocompleteResponse =
+                new Gson().fromJson(transformed, AutocompleteResponse.class);
+        autocompleteResponse.setHeaders(headers);
+
+        return autocompleteResponse;
     }
 
     /**
@@ -2217,6 +2239,11 @@ public class ConstructorIO {
      * in a Gson Type Adapter.
      */
     protected static SearchResponse createSearchResponse(String string) {
+        return createSearchResponse(string, null);
+    }
+
+    protected static SearchResponse createSearchResponse(
+            String string, Map<String, List<String>> headers) {
         JSONObject json = new JSONObject(string);
         JSONObject response = json.getJSONObject("response");
         JSONArray results;
@@ -2227,7 +2254,9 @@ public class ConstructorIO {
         }
 
         String transformed = json.toString();
-        return new Gson().fromJson(transformed, SearchResponse.class);
+        SearchResponse searchResponse = new Gson().fromJson(transformed, SearchResponse.class);
+        searchResponse.setHeaders(headers);
+        return searchResponse;
     }
 
     /**

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -968,66 +968,73 @@ public class ConstructorIO {
      * @throws ConstructorException
      */
     protected Request createAutocompleteRequest(AutocompleteRequest req, UserInfo userInfo)
-            throws ConstructorException, UnsupportedEncodingException {
-        List<String> paths = Arrays.asList("autocomplete", req.getQuery());
-        HttpUrl url = (userInfo == null) ? this.makeUrl(paths) : this.makeUrl(paths, userInfo);
+            throws ConstructorException {
+        try {
+            List<String> paths = Arrays.asList("autocomplete", req.getQuery());
+            HttpUrl url = (userInfo == null) ? this.makeUrl(paths) : this.makeUrl(paths, userInfo);
 
-        for (Map.Entry<String, Integer> entry : req.getResultsPerSection().entrySet()) {
-            String section = entry.getKey();
-            String count = String.valueOf(entry.getValue());
-            url = url.newBuilder().addQueryParameter("num_results_" + section, count).build();
-        }
+            for (Map.Entry<String, Integer> entry : req.getResultsPerSection().entrySet()) {
+                String section = entry.getKey();
+                String count = String.valueOf(entry.getValue());
+                url = url.newBuilder().addQueryParameter("num_results_" + section, count).build();
+            }
 
-        for (String hiddenField : req.getHiddenFields()) {
-            url =
-                    url.newBuilder()
-                            .addQueryParameter("fmt_options[hidden_fields]", hiddenField)
-                            .build();
-        }
-
-        for (String filterName : req.getFilters().keySet()) {
-            for (String facetValue : req.getFilters().get(filterName)) {
+            for (String hiddenField : req.getHiddenFields()) {
                 url =
                         url.newBuilder()
-                                .addQueryParameter("filters[" + filterName + "]", facetValue)
+                                .addQueryParameter("fmt_options[hidden_fields]", hiddenField)
                                 .build();
             }
-        }
 
-        for (String sectionName : req.getFiltersPerSection().keySet()) {
-            for (String filterName : req.getFiltersPerSection().get(sectionName).keySet()) {
-                for (String facetValue :
-                        req.getFiltersPerSection().get(sectionName).get(filterName)) {
+            for (String filterName : req.getFilters().keySet()) {
+                for (String facetValue : req.getFilters().get(filterName)) {
                     url =
                             url.newBuilder()
-                                    .addQueryParameter(
-                                            "filters"
-                                                    + "["
-                                                    + sectionName
-                                                    + "]"
-                                                    + "["
-                                                    + filterName
-                                                    + "]",
-                                            facetValue)
+                                    .addQueryParameter("filters[" + filterName + "]", facetValue)
                                     .build();
                 }
             }
-        }
 
-        if (req.getVariationsMap() != null) {
-            String variationsMapJson = new Gson().toJson(req.getVariationsMap());
-            url = url.newBuilder().addQueryParameter("variations_map", variationsMapJson).build();
-        }
+            for (String sectionName : req.getFiltersPerSection().keySet()) {
+                for (String filterName : req.getFiltersPerSection().get(sectionName).keySet()) {
+                    for (String facetValue :
+                            req.getFiltersPerSection().get(sectionName).get(filterName)) {
+                        url =
+                                url.newBuilder()
+                                        .addQueryParameter(
+                                                "filters"
+                                                        + "["
+                                                        + sectionName
+                                                        + "]"
+                                                        + "["
+                                                        + filterName
+                                                        + "]",
+                                                facetValue)
+                                        .build();
+                    }
+                }
+            }
 
-        if (req.getPreFilterExpression() != null) {
-            url =
-                    url.newBuilder()
-                            .addQueryParameter(
-                                    "pre_filter_expression", req.getPreFilterExpression())
-                            .build();
-        }
+            if (req.getVariationsMap() != null) {
+                String variationsMapJson = new Gson().toJson(req.getVariationsMap());
+                url =
+                        url.newBuilder()
+                                .addQueryParameter("variations_map", variationsMapJson)
+                                .build();
+            }
 
-        return this.makeUserRequestBuilder(userInfo).url(url).get().build();
+            if (req.getPreFilterExpression() != null) {
+                url =
+                        url.newBuilder()
+                                .addQueryParameter(
+                                        "pre_filter_expression", req.getPreFilterExpression())
+                                .build();
+            }
+
+            return this.makeUserRequestBuilder(userInfo).url(url).get().build();
+        } catch (Exception exception) {
+            throw new ConstructorException(exception);
+        }
     }
 
     /**

--- a/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
+++ b/constructorio-client/src/main/java/io/constructor/client/ConstructorIO.java
@@ -12,6 +12,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -925,7 +926,7 @@ public class ConstructorIO {
      */
     public AutocompleteResponse autocomplete(AutocompleteRequest req, UserInfo userInfo)
             throws ConstructorException {
-        Map<String, List<String>> headers = null;
+        Map<String, List<String>> headers = Collections.<String, List<String>>emptyMap();
         try {
             Request request = createAutocompleteRequest(req, userInfo);
             Response response = clientWithRetry.newCall(request).execute();
@@ -1190,7 +1191,7 @@ public class ConstructorIO {
      * @throws ConstructorException if the request is invalid.
      */
     public SearchResponse search(SearchRequest req, UserInfo userInfo) throws ConstructorException {
-        Map<String, List<String>> headers = null;
+        Map<String, List<String>> headers = Collections.<String, List<String>>emptyMap();
         try {
             Request request = createSearchRequest(req, userInfo);
             Response response = clientWithRetry.newCall(request).execute();
@@ -1232,7 +1233,8 @@ public class ConstructorIO {
                                 @Override
                                 public void onResponse(Call call, final Response response)
                                         throws IOException {
-                                    Map<String, List<String>> headers = null;
+                                    Map<String, List<String>> headers =
+                                            Collections.<String, List<String>>emptyMap();
                                     try {
                                         headers = response.headers().toMultimap();
                                         String json = getResponseBody(response);
@@ -2233,6 +2235,13 @@ public class ConstructorIO {
         return createAutocompleteResponse(string, null);
     }
 
+    /**
+     * Transforms a JSON string to an AutocompleteResponse, setting the provided HTTP headers.
+     *
+     * @param string the JSON response string
+     * @param headers the HTTP response headers, or null for an empty map
+     * @return the parsed AutocompleteResponse
+     */
     protected static AutocompleteResponse createAutocompleteResponse(
             String string, Map<String, List<String>> headers) {
         JSONObject json = new JSONObject(string);
@@ -2259,6 +2268,13 @@ public class ConstructorIO {
         return createSearchResponse(string, null);
     }
 
+    /**
+     * Transforms a JSON string to a SearchResponse, setting the provided HTTP headers.
+     *
+     * @param string the JSON response string
+     * @param headers the HTTP response headers, or null for an empty map
+     * @return the parsed SearchResponse
+     */
     protected static SearchResponse createSearchResponse(
             String string, Map<String, List<String>> headers) {
         JSONObject json = new JSONObject(string);

--- a/constructorio-client/src/main/java/io/constructor/client/models/AutocompleteResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/AutocompleteResponse.java
@@ -1,12 +1,11 @@
 package io.constructor.client.models;
 
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 /** Constructor.io Autocomplete Response ... uses Gson/Reflection to load data in */
-public class AutocompleteResponse {
+public class AutocompleteResponse extends ResponseHeaders {
 
     @SerializedName("sections")
     private Map<String, List<Result>> sections;
@@ -16,9 +15,6 @@ public class AutocompleteResponse {
 
     @SerializedName("request")
     private Map<String, Object> request;
-
-    private transient Map<String, List<String>> headers =
-            Collections.<String, List<String>>emptyMap();
 
     /**
      * @return the resultId
@@ -41,13 +37,6 @@ public class AutocompleteResponse {
         return request;
     }
 
-    /**
-     * @return the HTTP response headers
-     */
-    public Map<String, List<String>> getHeaders() {
-        return headers;
-    }
-
     public void setSections(Map<String, List<Result>> sections) {
         this.sections = sections;
     }
@@ -58,9 +47,5 @@ public class AutocompleteResponse {
 
     public void setRequest(Map<String, Object> request) {
         this.request = request;
-    }
-
-    public void setHeaders(Map<String, List<String>> headers) {
-        this.headers = (headers != null) ? headers : Collections.<String, List<String>>emptyMap();
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/AutocompleteResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/AutocompleteResponse.java
@@ -48,4 +48,17 @@ public class AutocompleteResponse {
     public void setRequest(Map<String, Object> request) {
         this.request = request;
     }
+
+    private transient Map<String, List<String>> headers;
+
+    /**
+     * @return the HTTP response headers, or null if not available
+     */
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, List<String>> headers) {
+        this.headers = headers;
+    }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/AutocompleteResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/AutocompleteResponse.java
@@ -1,6 +1,7 @@
 package io.constructor.client.models;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -15,6 +16,8 @@ public class AutocompleteResponse {
 
     @SerializedName("request")
     private Map<String, Object> request;
+
+    private transient Map<String, List<String>> headers = Collections.emptyMap();
 
     /**
      * @return the resultId
@@ -37,6 +40,13 @@ public class AutocompleteResponse {
         return request;
     }
 
+    /**
+     * @return the HTTP response headers
+     */
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
     public void setSections(Map<String, List<Result>> sections) {
         this.sections = sections;
     }
@@ -49,16 +59,7 @@ public class AutocompleteResponse {
         this.request = request;
     }
 
-    private transient Map<String, List<String>> headers;
-
-    /**
-     * @return the HTTP response headers, or null if not available
-     */
-    public Map<String, List<String>> getHeaders() {
-        return headers;
-    }
-
     public void setHeaders(Map<String, List<String>> headers) {
-        this.headers = headers;
+        this.headers = (headers != null) ? headers : Collections.emptyMap();
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/AutocompleteResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/AutocompleteResponse.java
@@ -17,7 +17,8 @@ public class AutocompleteResponse {
     @SerializedName("request")
     private Map<String, Object> request;
 
-    private transient Map<String, List<String>> headers = Collections.emptyMap();
+    private transient Map<String, List<String>> headers =
+            Collections.<String, List<String>>emptyMap();
 
     /**
      * @return the resultId
@@ -60,6 +61,6 @@ public class AutocompleteResponse {
     }
 
     public void setHeaders(Map<String, List<String>> headers) {
-        this.headers = (headers != null) ? headers : Collections.emptyMap();
+        this.headers = (headers != null) ? headers : Collections.<String, List<String>>emptyMap();
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/ResponseHeaders.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/ResponseHeaders.java
@@ -4,7 +4,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-/** Base class that provides access to HTTP response headers. */
+/**
+ * Base class that provides access to HTTP response headers. Abstract rather than an interface
+ * because Java 7 does not support default methods, and we want to avoid duplicating the field and
+ * method bodies in every response class.
+ */
 public abstract class ResponseHeaders {
 
     private transient Map<String, List<String>> headers =

--- a/constructorio-client/src/main/java/io/constructor/client/models/ResponseHeaders.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/ResponseHeaders.java
@@ -1,0 +1,26 @@
+package io.constructor.client.models;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** Base class that provides access to HTTP response headers. */
+public abstract class ResponseHeaders {
+
+    private transient Map<String, List<String>> headers =
+            Collections.<String, List<String>>emptyMap();
+
+    /**
+     * @return the HTTP response headers
+     */
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * @param headers the HTTP response headers to set. If null, defaults to an empty map.
+     */
+    public void setHeaders(Map<String, List<String>> headers) {
+        this.headers = (headers != null) ? headers : Collections.<String, List<String>>emptyMap();
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/models/SearchResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/SearchResponse.java
@@ -1,12 +1,10 @@
 package io.constructor.client.models;
 
 import com.google.gson.annotations.SerializedName;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /** Constructor.io Search Response ... uses Gson/Reflection to load data in */
-public class SearchResponse {
+public class SearchResponse extends ResponseHeaders {
 
     @SerializedName("result_id")
     private String resultId;
@@ -16,9 +14,6 @@ public class SearchResponse {
 
     @SerializedName("request")
     private Map<String, Object> request;
-
-    private transient Map<String, List<String>> headers =
-            Collections.<String, List<String>>emptyMap();
 
     /**
      * @return the resultId
@@ -41,13 +36,6 @@ public class SearchResponse {
         return request;
     }
 
-    /**
-     * @return the HTTP response headers
-     */
-    public Map<String, List<String>> getHeaders() {
-        return headers;
-    }
-
     public void setResultId(String resultId) {
         this.resultId = resultId;
     }
@@ -58,9 +46,5 @@ public class SearchResponse {
 
     public void setRequest(Map<String, Object> request) {
         this.request = request;
-    }
-
-    public void setHeaders(Map<String, List<String>> headers) {
-        this.headers = (headers != null) ? headers : Collections.<String, List<String>>emptyMap();
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/SearchResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/SearchResponse.java
@@ -17,7 +17,8 @@ public class SearchResponse {
     @SerializedName("request")
     private Map<String, Object> request;
 
-    private transient Map<String, List<String>> headers = Collections.emptyMap();
+    private transient Map<String, List<String>> headers =
+            Collections.<String, List<String>>emptyMap();
 
     /**
      * @return the resultId
@@ -60,6 +61,6 @@ public class SearchResponse {
     }
 
     public void setHeaders(Map<String, List<String>> headers) {
-        this.headers = (headers != null) ? headers : Collections.emptyMap();
+        this.headers = (headers != null) ? headers : Collections.<String, List<String>>emptyMap();
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/SearchResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/SearchResponse.java
@@ -1,6 +1,7 @@
 package io.constructor.client.models;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -15,6 +16,8 @@ public class SearchResponse {
 
     @SerializedName("request")
     private Map<String, Object> request;
+
+    private transient Map<String, List<String>> headers = Collections.emptyMap();
 
     /**
      * @return the resultId
@@ -37,6 +40,13 @@ public class SearchResponse {
         return request;
     }
 
+    /**
+     * @return the HTTP response headers
+     */
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
     public void setResultId(String resultId) {
         this.resultId = resultId;
     }
@@ -49,16 +59,7 @@ public class SearchResponse {
         this.request = request;
     }
 
-    private transient Map<String, List<String>> headers;
-
-    /**
-     * @return the HTTP response headers, or null if not available
-     */
-    public Map<String, List<String>> getHeaders() {
-        return headers;
-    }
-
     public void setHeaders(Map<String, List<String>> headers) {
-        this.headers = headers;
+        this.headers = (headers != null) ? headers : Collections.emptyMap();
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/models/SearchResponse.java
+++ b/constructorio-client/src/main/java/io/constructor/client/models/SearchResponse.java
@@ -1,6 +1,7 @@
 package io.constructor.client.models;
 
 import com.google.gson.annotations.SerializedName;
+import java.util.List;
 import java.util.Map;
 
 /** Constructor.io Search Response ... uses Gson/Reflection to load data in */
@@ -46,5 +47,18 @@ public class SearchResponse {
 
     public void setRequest(Map<String, Object> request) {
         this.request = request;
+    }
+
+    private transient Map<String, List<String>> headers;
+
+    /**
+     * @return the HTTP response headers, or null if not available
+     */
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, List<String>> headers) {
+        this.headers = headers;
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteUrlEncodingTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteUrlEncodingTest.java
@@ -1,7 +1,11 @@
 package io.constructor.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
+import io.constructor.client.models.AutocompleteResponse;
+import java.util.List;
+import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -41,8 +45,7 @@ public class ConstructorIOAutocompleteUrlEncodingTest {
         constructor.autocomplete(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath =
-                String.format("/autocomplete/r%%2Bco?key=%s&c=ciojava-7.5.0", apiKey);
+        String expectedPath = String.format("/autocomplete/r%%2Bco?key=%s&c=ciojava-7.5.0", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }
@@ -59,8 +62,7 @@ public class ConstructorIOAutocompleteUrlEncodingTest {
         constructor.autocomplete(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath =
-                String.format("/autocomplete/r%%20co?key=%s&c=ciojava-7.5.0", apiKey);
+        String expectedPath = String.format("/autocomplete/r%%20co?key=%s&c=ciojava-7.5.0", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }
@@ -77,8 +79,7 @@ public class ConstructorIOAutocompleteUrlEncodingTest {
         constructor.autocomplete(request, null);
 
         RecordedRequest recordedRequest = mockServer.takeRequest();
-        String expectedPath =
-                String.format("/autocomplete/r%%2Fco?key=%s&c=ciojava-7.5.0", apiKey);
+        String expectedPath = String.format("/autocomplete/r%%2Fco?key=%s&c=ciojava-7.5.0", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
     }
@@ -98,5 +99,33 @@ public class ConstructorIOAutocompleteUrlEncodingTest {
         String expectedPath = String.format("/autocomplete/r'co?key=%s&c=ciojava-7.5.0", apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
+    }
+
+    @Test
+    public void AutocompleteShouldReturnRateLimitHeaders() throws Exception {
+        String string = Utils.getTestResource("response.autocomplete.peanut.json");
+        MockResponse mockResponse =
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(string)
+                        .addHeader("X-RateLimit-Limit", "100")
+                        .addHeader("X-RateLimit-Remaining", "99")
+                        .addHeader("X-RateLimit-Reset", "1620000000");
+        mockServer.enqueue(mockResponse);
+
+        ConstructorIO constructor =
+                new ConstructorIO("", apiKey, false, "127.0.0.1", mockServer.getPort());
+        AutocompleteRequest request = new AutocompleteRequest("peanut");
+        AutocompleteResponse response = constructor.autocomplete(request, null);
+
+        mockServer.takeRequest();
+
+        Map<String, List<String>> headers = response.getHeaders();
+        assertNotNull("headers should not be null", headers);
+        assertEquals("rate limit header", "100", headers.get("x-ratelimit-limit").get(0));
+        assertEquals(
+                "rate limit remaining header", "99", headers.get("x-ratelimit-remaining").get(0));
+        assertEquals(
+                "rate limit reset header", "1620000000", headers.get("x-ratelimit-reset").get(0));
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteUrlEncodingTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOAutocompleteUrlEncodingTest.java
@@ -2,6 +2,7 @@ package io.constructor.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import io.constructor.client.models.AutocompleteResponse;
 import java.util.List;
@@ -127,5 +128,40 @@ public class ConstructorIOAutocompleteUrlEncodingTest {
                 "rate limit remaining header", "99", headers.get("x-ratelimit-remaining").get(0));
         assertEquals(
                 "rate limit reset header", "1620000000", headers.get("x-ratelimit-reset").get(0));
+    }
+
+    @Test
+    public void AutocompleteShouldReturnRateLimitHeadersOnError() throws Exception {
+        MockResponse mockResponse =
+                new MockResponse()
+                        .setResponseCode(429)
+                        .setBody("{\"message\":\"Too Many Requests\"}")
+                        .addHeader("X-RateLimit-Limit", "100")
+                        .addHeader("X-RateLimit-Remaining", "0")
+                        .addHeader("X-RateLimit-Reset", "1620000060");
+        mockServer.enqueue(mockResponse);
+
+        ConstructorIO constructor =
+                new ConstructorIO("", apiKey, false, "127.0.0.1", mockServer.getPort());
+        AutocompleteRequest request = new AutocompleteRequest("peanut");
+
+        try {
+            constructor.autocomplete(request, null);
+            fail("Expected ConstructorException to be thrown");
+        } catch (ConstructorException e) {
+            mockServer.takeRequest();
+
+            Map<String, List<String>> headers = e.getHeaders();
+            assertNotNull("headers should not be null", headers);
+            assertEquals("rate limit header", "100", headers.get("x-ratelimit-limit").get(0));
+            assertEquals(
+                    "rate limit remaining header",
+                    "0",
+                    headers.get("x-ratelimit-remaining").get(0));
+            assertEquals(
+                    "rate limit reset header",
+                    "1620000060",
+                    headers.get("x-ratelimit-reset").get(0));
+        }
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOItemsTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOItemsTest.java
@@ -30,7 +30,9 @@ public class ConstructorIOItemsTest {
         ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
 
         constructor.deleteItems(
-                itemsToCleanup.toArray(new ConstructorItem[itemsToCleanup.size()]), "Products", true);
+                itemsToCleanup.toArray(new ConstructorItem[itemsToCleanup.size()]),
+                "Products",
+                true);
     }
 
     @Rule public ExpectedException thrown = ExpectedException.none();

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOItemsTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOItemsTest.java
@@ -30,7 +30,7 @@ public class ConstructorIOItemsTest {
         ConstructorIO constructor = new ConstructorIO(token, apiKey, true, null);
 
         constructor.deleteItems(
-                itemsToCleanup.toArray(new ConstructorItem[itemsToCleanup.size()]), "Products");
+                itemsToCleanup.toArray(new ConstructorItem[itemsToCleanup.size()]), "Products", true);
     }
 
     @Rule public ExpectedException thrown = ExpectedException.none();

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchUrlEncodingTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchUrlEncodingTest.java
@@ -1,7 +1,11 @@
 package io.constructor.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
+import io.constructor.client.models.SearchResponse;
+import java.util.List;
+import java.util.Map;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -107,5 +111,33 @@ public class ConstructorIOSearchUrlEncodingTest {
                         apiKey);
         String actualPath = recordedRequest.getPath();
         assertEquals("recorded request is encoded correctly", actualPath, expectedPath);
+    }
+
+    @Test
+    public void SearchShouldReturnRateLimitHeaders() throws Exception {
+        String string = Utils.getTestResource("response.search.peanut.json");
+        MockResponse mockResponse =
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(string)
+                        .addHeader("X-RateLimit-Limit", "100")
+                        .addHeader("X-RateLimit-Remaining", "99")
+                        .addHeader("X-RateLimit-Reset", "1620000000");
+        mockServer.enqueue(mockResponse);
+
+        ConstructorIO constructor =
+                new ConstructorIO("", apiKey, false, "127.0.0.1", mockServer.getPort());
+        SearchRequest request = new SearchRequest("peanut");
+        SearchResponse response = constructor.search(request, null);
+
+        mockServer.takeRequest();
+
+        Map<String, List<String>> headers = response.getHeaders();
+        assertNotNull("headers should not be null", headers);
+        assertEquals("rate limit header", "100", headers.get("x-ratelimit-limit").get(0));
+        assertEquals(
+                "rate limit remaining header", "99", headers.get("x-ratelimit-remaining").get(0));
+        assertEquals(
+                "rate limit reset header", "1620000000", headers.get("x-ratelimit-reset").get(0));
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchUrlEncodingTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOSearchUrlEncodingTest.java
@@ -2,6 +2,7 @@ package io.constructor.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import io.constructor.client.models.SearchResponse;
 import java.util.List;
@@ -139,5 +140,40 @@ public class ConstructorIOSearchUrlEncodingTest {
                 "rate limit remaining header", "99", headers.get("x-ratelimit-remaining").get(0));
         assertEquals(
                 "rate limit reset header", "1620000000", headers.get("x-ratelimit-reset").get(0));
+    }
+
+    @Test
+    public void SearchShouldReturnRateLimitHeadersOnError() throws Exception {
+        MockResponse mockResponse =
+                new MockResponse()
+                        .setResponseCode(429)
+                        .setBody("{\"message\":\"Too Many Requests\"}")
+                        .addHeader("X-RateLimit-Limit", "100")
+                        .addHeader("X-RateLimit-Remaining", "0")
+                        .addHeader("X-RateLimit-Reset", "1620000060");
+        mockServer.enqueue(mockResponse);
+
+        ConstructorIO constructor =
+                new ConstructorIO("", apiKey, false, "127.0.0.1", mockServer.getPort());
+        SearchRequest request = new SearchRequest("peanut");
+
+        try {
+            constructor.search(request, null);
+            fail("Expected ConstructorException to be thrown");
+        } catch (ConstructorException e) {
+            mockServer.takeRequest();
+
+            Map<String, List<String>> headers = e.getHeaders();
+            assertNotNull("headers should not be null", headers);
+            assertEquals("rate limit header", "100", headers.get("x-ratelimit-limit").get(0));
+            assertEquals(
+                    "rate limit remaining header",
+                    "0",
+                    headers.get("x-ratelimit-remaining").get(0));
+            assertEquals(
+                    "rate limit reset header",
+                    "1620000060",
+                    headers.get("x-ratelimit-reset").get(0));
+        }
     }
 }

--- a/constructorio-client/src/test/java/io/constructor/client/ConstructorIOVariationsTest.java
+++ b/constructorio-client/src/test/java/io/constructor/client/ConstructorIOVariationsTest.java
@@ -32,7 +32,8 @@ public class ConstructorIOVariationsTest {
 
         constructor.deleteVariations(
                 variationsToCleanup.toArray(new ConstructorVariation[variationsToCleanup.size()]),
-                "Products");
+                "Products",
+                true);
     }
 
     @Rule public ExpectedException thrown = ExpectedException.none();


### PR DESCRIPTION
## PR Description
This change refactors the internal calling structure of `autocomplete` and `search` to allow headers to be exposed. Headers  are now exposed via the new method `getHeaders()` available on the types: `AutocompleteResponse` & `SearchResponse`

`getHeaders` returns a `Map<String, List<String>>` object containing the headers.

E.g.
```java
        SearchResponse response = constructor.search(request, userInfo);
        Map<String, List<String>> headers = response.getHeaders();

        // Get the ratelimit headers
        String rateLimit = headers.get("x-ratelimit-limit").get(0);
        String rateLimitLeft = headers.get("x-ratelimit-remaining").get(0);
        String rateLimitResetTimestamp = headers.get("x-ratelimit-reset").get(0);
```

## Considerations
1. This change is backwards compatible as existing consumer patterns are unchanged
2. Headers are not strongly typed
3. Search & Autocomplete to be released first. Browse and other responses to follow shortly after