### PR TITLE
add a common object for browse and search request

### DIFF
--- a/constructorio-client/src/main/java/io/constructor/client/BrowseRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/BrowseRequest.java
@@ -1,31 +1,10 @@
 package io.constructor.client;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /** Constructor.io Browse Request */
-public class BrowseRequest {
+public class BrowseRequest extends BrowseSearchBaseRequest {
 
     private String filterName;
     private String filterValue;
-    private String section;
-    private int page;
-    private int resultsPerPage;
-    private Map<String, List<String>> facets;
-    private String groupId;
-    private String sortBy;
-    private boolean sortAscending;
-    private Map<String, String> formatOptions;
-    private List<String> hiddenFields;
-    private List<String> hiddenFacets;
-    private VariationsMap variationsMap;
-    private String preFilterExpression;
-    private String qsParam;
-    private String now;
-    private int offset;
-    private Map<String, String> filterMatchTypes;
 
     /**
      * Creates a browse request
@@ -34,29 +13,15 @@ public class BrowseRequest {
      * @param filterValue filter value to display results from
      */
     public BrowseRequest(String filterName, String filterValue) throws IllegalArgumentException {
+        super();
         if (filterName == null) {
             throw new IllegalArgumentException("filterName is required");
         }
         if (filterValue == null) {
             throw new IllegalArgumentException("filterValue is required");
         }
-
         this.filterName = filterName;
         this.filterValue = filterValue;
-        this.section = "Products";
-        this.page = 1;
-        this.resultsPerPage = 30;
-        this.facets = new HashMap<String, List<String>>();
-        this.sortAscending = true;
-        this.formatOptions = new HashMap<String, String>();
-        this.hiddenFields = new ArrayList<String>();
-        this.hiddenFacets = new ArrayList<String>();
-        this.variationsMap = null;
-        this.preFilterExpression = null;
-        this.qsParam = null;
-        this.now = null;
-        this.offset = 0;
-        this.filterMatchTypes = new HashMap<String, String>();
     }
 
     /**
@@ -85,238 +50,5 @@ public class BrowseRequest {
      */
     public String getFilterValue() {
         return filterValue;
-    }
-
-    /**
-     * @return the section
-     */
-    public String getSection() {
-        return section;
-    }
-
-    /**
-     * @param section the section to set
-     */
-    public void setSection(String section) {
-        this.section = section;
-    }
-
-    /**
-     * @return the page
-     */
-    public int getPage() {
-        return page;
-    }
-
-    /**
-     * @param page the page to set (Can't be used together with the 'offset' parameter)
-     */
-    public void setPage(int page) {
-        this.page = page;
-    }
-
-    /**
-     * @return the resultsPerPage
-     */
-    public int getResultsPerPage() {
-        return resultsPerPage;
-    }
-
-    /**
-     * @param resultsPerPage the resultsPerPage to set
-     */
-    public void setResultsPerPage(int resultsPerPage) {
-        this.resultsPerPage = resultsPerPage;
-    }
-
-    /**
-     * @return the groupId
-     */
-    public String getGroupId() {
-        return groupId;
-    }
-
-    /**
-     * @param groupId the groupId to set
-     */
-    public void setGroupId(String groupId) {
-        this.groupId = groupId;
-    }
-
-    /**
-     * @param facets the facets to set
-     */
-    public void setFacets(Map<String, List<String>> facets) {
-        this.facets = facets;
-    }
-
-    /**
-     * @return the facets
-     */
-    public Map<String, List<String>> getFacets() {
-        return facets;
-    }
-
-    /**
-     * @param sortBy the sortBy to set
-     */
-    public void setSortBy(String sortBy) {
-        this.sortBy = sortBy;
-    }
-
-    /**
-     * @return the sortBy
-     */
-    public String getSortBy() {
-        return sortBy;
-    }
-
-    /**
-     * @param sortAscending the sortAscending to set
-     */
-    public void setSortAscending(boolean sortAscending) {
-        this.sortAscending = sortAscending;
-    }
-
-    /**
-     * @return the sortAscending
-     */
-    public boolean getSortAscending() {
-        return sortAscending;
-    }
-
-    /**
-     * @param formatOptions the formatOptions to set. Please refer to
-     *     https://docs.constructor.com/reference/v1-search-get-search-results for details
-     */
-    public void setFormatOptions(Map<String, String> formatOptions) {
-        this.formatOptions = formatOptions;
-    }
-
-    /**
-     * @return the format options
-     */
-    public Map<String, String> getFormatOptions() {
-        return formatOptions;
-    }
-
-    /**
-     * @param hiddenFields the hiddenFields to set
-     */
-    public void setHiddenFields(List<String> hiddenFields) {
-        this.hiddenFields = hiddenFields;
-    }
-
-    /**
-     * @return the hidden fields
-     */
-    public List<String> getHiddenFields() {
-        return hiddenFields;
-    }
-
-    /**
-     * @param hiddenFacets the hiddenFacets to set
-     */
-    public void setHiddenFacets(List<String> hiddenFacets) {
-        this.hiddenFacets = hiddenFacets;
-    }
-
-    /**
-     * @return the hidden facets
-     */
-    public List<String> getHiddenFacets() {
-        return hiddenFacets;
-    }
-
-    /**
-     * @param variationsMap the variationsMap to set
-     */
-    public void setVariationsMap(VariationsMap variationsMap) {
-        this.variationsMap = variationsMap;
-    }
-
-    /**
-     * @return the variations map
-     */
-    public VariationsMap getVariationsMap() {
-        return variationsMap;
-    }
-
-    /**
-     * @param preFilterExpression the faceting expression to scope search results (JSON-encoded
-     *     query string). Please refer to
-     *     https://docs.constructor.com/reference/shared-filter-expressions
-     */
-    public void setPreFilterExpression(String preFilterExpression) {
-        this.preFilterExpression = preFilterExpression;
-    }
-
-    /**
-     * @return the prefilter expression
-     */
-    public String getPreFilterExpression() {
-        return preFilterExpression;
-    }
-
-    /**
-     * @param qsParam any parameters listed in the API documentation can be serialized into a JSON
-     *     object and parsed through this parameter. Please refer to
-     *     https://docs.constructor.com/reference/v1-search-get-search-results/
-     */
-    public void setQsParam(String qsParam) {
-        this.qsParam = qsParam;
-    }
-
-    /**
-     * @return the qs parameter
-     */
-    public String getQsParam() {
-        return qsParam;
-    }
-
-    /**
-     * @param now a unix epoch timestamp used to emulate "past" and "future" requests. Please refer
-     *     to https://docs.constructor.com/reference/v1-search-get-search-results/
-     */
-    public void setNow(String now) {
-        this.now = now;
-    }
-
-    /**
-     * @return the now parameter
-     */
-    public String getNow() {
-        return now;
-    }
-
-    /**
-     * @param offset the number of results to skip from the beginning (Can't be used together with
-     *     the 'page' parameter).
-     */
-    public void setOffset(int offset) {
-        this.offset = offset;
-    }
-
-    /**
-     * @return the offset
-     */
-    public int getOffset() {
-        return offset;
-    }
-
-    /**
-     * @param filterMatchTypes the filterMatchTypes to set. Please refer to
-     *     https://docs.constructor.com/reference/v1-browse-get-browse-results for details
-     *     Possible values 'all', 'any' or 'none'
-     */
-    public void setFilterMatchTypes(Map<String, String> filterMatchTypes) {
-        this.filterMatchTypes = filterMatchTypes;
-    }
-
-    /**
-     * @return the filterMatchTypes
-     */
-    public Map<String, String> getFilterMatchTypes() {
-        return filterMatchTypes;
     }
 }

--- a/constructorio-client/src/main/java/io/constructor/client/BrowseSearchBaseRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/BrowseSearchBaseRequest.java
@@ -1,0 +1,281 @@
+package io.constructor.client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Constructor.io base Search/Browse Request */
+public class BrowseSearchBaseRequest {
+
+    private String section;
+    private int page;
+    private int resultsPerPage;
+    private Map<String, List<String>> facets;
+    private String groupId;
+    private String sortBy;
+    private boolean sortAscending;
+    private Map<String, String> formatOptions;
+    private List<String> hiddenFields;
+    private List<String> hiddenFacets;
+    private VariationsMap variationsMap;
+    private String preFilterExpression;
+    private String qsParam;
+    private String now;
+    private int offset;
+    private Map<String, String> filterMatchTypes;
+
+    /**
+     * Object with common request fields of search and browse
+     *
+     */
+    public BrowseSearchBaseRequest() {
+
+        this.section = "Products";
+        this.page = 1;
+        this.resultsPerPage = 30;
+        this.facets = new HashMap<String, List<String>>();
+        this.sortAscending = true;
+        this.formatOptions = new HashMap<String, String>();
+        this.hiddenFields = new ArrayList<String>();
+        this.hiddenFacets = new ArrayList<String>();
+        this.variationsMap = null;
+        this.preFilterExpression = null;
+        this.qsParam = null;
+        this.now = null;
+        this.offset = 0;
+        this.filterMatchTypes = new HashMap<String, String>();
+    }
+
+    /**
+     * @return the section
+     */
+    public String getSection() {
+        return section;
+    }
+
+    /**
+     * @param section the section to set
+     */
+    public void setSection(String section) {
+        this.section = section;
+    }
+
+    /**
+     * @return the page
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     * @param page the page to set (Can't be used together with the 'offset' parameter)
+     */
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    /**
+     * @return the resultsPerPage
+     */
+    public int getResultsPerPage() {
+        return resultsPerPage;
+    }
+
+    /**
+     * @param resultsPerPage the resultsPerPage to set
+     */
+    public void setResultsPerPage(int resultsPerPage) {
+        this.resultsPerPage = resultsPerPage;
+    }
+
+    /**
+     * @return the groupId
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @param groupId the groupId to set
+     */
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    /**
+     * @param facets the facets to set
+     */
+    public void setFacets(Map<String, List<String>> facets) {
+        this.facets = facets;
+    }
+
+    /**
+     * @return the facets
+     */
+    public Map<String, List<String>> getFacets() {
+        return facets;
+    }
+
+    /**
+     * @param sortBy the sortBy to set
+     */
+    public void setSortBy(String sortBy) {
+        this.sortBy = sortBy;
+    }
+
+    /**
+     * @return the sortBy
+     */
+    public String getSortBy() {
+        return sortBy;
+    }
+
+    /**
+     * @param sortAscending the sortAscending to set
+     */
+    public void setSortAscending(boolean sortAscending) {
+        this.sortAscending = sortAscending;
+    }
+
+    /**
+     * @return the sortAscending
+     */
+    public boolean getSortAscending() {
+        return sortAscending;
+    }
+
+    /**
+     * @param formatOptions the formatOptions to set. Please refer to
+     *     https://docs.constructor.com/reference/v1-search-get-search-results for details
+     */
+    public void setFormatOptions(Map<String, String> formatOptions) {
+        this.formatOptions = formatOptions;
+    }
+
+    /**
+     * @return the format options
+     */
+    public Map<String, String> getFormatOptions() {
+        return formatOptions;
+    }
+
+    /**
+     * @param hiddenFields the hiddenFields to set
+     */
+    public void setHiddenFields(List<String> hiddenFields) {
+        this.hiddenFields = hiddenFields;
+    }
+
+    /**
+     * @return the hidden fields
+     */
+    public List<String> getHiddenFields() {
+        return hiddenFields;
+    }
+
+    /**
+     * @param hiddenFacets the hiddenFacets to set
+     */
+    public void setHiddenFacets(List<String> hiddenFacets) {
+        this.hiddenFacets = hiddenFacets;
+    }
+
+    /**
+     * @return the hidden facets
+     */
+    public List<String> getHiddenFacets() {
+        return hiddenFacets;
+    }
+
+    /**
+     * @param variationsMap the variationsMap to set
+     */
+    public void setVariationsMap(VariationsMap variationsMap) {
+        this.variationsMap = variationsMap;
+    }
+
+    /**
+     * @return the variations map
+     */
+    public VariationsMap getVariationsMap() {
+        return variationsMap;
+    }
+
+    /**
+     * @param preFilterExpression the faceting expression to scope search results (JSON-encoded
+     *     query string). Please refer to
+     *     https://docs.constructor.com/reference/shared-filter-expressions
+     */
+    public void setPreFilterExpression(String preFilterExpression) {
+        this.preFilterExpression = preFilterExpression;
+    }
+
+    /**
+     * @return the prefilter expression
+     */
+    public String getPreFilterExpression() {
+        return preFilterExpression;
+    }
+
+    /**
+     * @param qsParam any parameters listed in the API documentation can be serialized into a JSON
+     *     object and parsed through this parameter. Please refer to
+     *     https://docs.constructor.com/reference/v1-search-get-search-results/
+     */
+    public void setQsParam(String qsParam) {
+        this.qsParam = qsParam;
+    }
+
+    /**
+     * @return the qs parameter
+     */
+    public String getQsParam() {
+        return qsParam;
+    }
+
+    /**
+     * @param now a unix epoch timestamp used to emulate "past" and "future" requests. Please refer
+     *     to https://docs.constructor.com/reference/v1-search-get-search-results/
+     */
+    public void setNow(String now) {
+        this.now = now;
+    }
+
+    /**
+     * @return the now parameter
+     */
+    public String getNow() {
+        return now;
+    }
+
+    /**
+     * @param offset the number of results to skip from the beginning (Can't be used together with
+     *     the 'page' parameter).
+     */
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+
+    /**
+     * @return the offset
+     */
+    public int getOffset() {
+        return offset;
+    }
+
+    /**
+     * @param filterMatchTypes the filterMatchTypes to set. Please refer to the relevant Search/Browse API endpoint documentation for details.
+     *     Possible values 'all', 'any' or 'none'
+     */
+    public void setFilterMatchTypes(Map<String, String> filterMatchTypes) {
+        this.filterMatchTypes = filterMatchTypes;
+    }
+
+    /**
+     * @return the filterMatchTypes
+     */
+    public Map<String, String> getFilterMatchTypes() {
+        return filterMatchTypes;
+    }
+}

--- a/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
+++ b/constructorio-client/src/main/java/io/constructor/client/SearchRequest.java
@@ -1,31 +1,10 @@
 package io.constructor.client;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /** Constructor.io Search Request */
-public class SearchRequest {
+public class SearchRequest extends BrowseSearchBaseRequest {
 
     private String query;
-    private String section;
-    private int page;
-    private int resultsPerPage;
-    private Map<String, List<String>> facets;
-    private String groupId;
-    private String sortBy;
-    private boolean sortAscending;
     private String collectionId;
-    private Map<String, String> formatOptions;
-    private List<String> hiddenFields;
-    private List<String> hiddenFacets;
-    private VariationsMap variationsMap;
-    private String preFilterExpression;
-    private String qsParam;
-    private String now;
-    private int offset;
-    private Map<String, String> filterMatchTypes;
 
     /**
      * Creates a search request
@@ -33,25 +12,11 @@ public class SearchRequest {
      * @param query the term to return search results for
      */
     public SearchRequest(String query) throws IllegalArgumentException {
+        super();
         if (query == null) {
             throw new IllegalArgumentException("query is required");
         }
-
         this.query = query;
-        this.section = "Products";
-        this.page = 1;
-        this.resultsPerPage = 30;
-        this.facets = new HashMap<String, List<String>>();
-        this.sortAscending = true;
-        this.formatOptions = new HashMap<String, String>();
-        this.hiddenFields = new ArrayList<String>();
-        this.hiddenFacets = new ArrayList<String>();
-        this.variationsMap = null;
-        this.preFilterExpression = null;
-        this.qsParam = null;
-        this.now = null;
-        this.offset = 0;
-        this.filterMatchTypes = new HashMap<String, String>();
     }
 
     /**
@@ -69,104 +34,6 @@ public class SearchRequest {
     }
 
     /**
-     * @return the section
-     */
-    public String getSection() {
-        return section;
-    }
-
-    /**
-     * @param section the section to set
-     */
-    public void setSection(String section) {
-        this.section = section;
-    }
-
-    /**
-     * @return the page
-     */
-    public int getPage() {
-        return page;
-    }
-
-    /**
-     * @param page the page to set (Can't be used together with the 'offset' parameter)
-     */
-    public void setPage(int page) {
-        this.page = page;
-    }
-
-    /**
-     * @return the resultsPerPage
-     */
-    public int getResultsPerPage() {
-        return resultsPerPage;
-    }
-
-    /**
-     * @param resultsPerPage the resultsPerPage to set
-     */
-    public void setResultsPerPage(int resultsPerPage) {
-        this.resultsPerPage = resultsPerPage;
-    }
-
-    /**
-     * @return the groupId
-     */
-    public String getGroupId() {
-        return groupId;
-    }
-
-    /**
-     * @param groupId the groupId to set
-     */
-    public void setGroupId(String groupId) {
-        this.groupId = groupId;
-    }
-
-    /**
-     * @param facets the facets to set
-     */
-    public void setFacets(Map<String, List<String>> facets) {
-        this.facets = facets;
-    }
-
-    /**
-     * @return the facets
-     */
-    public Map<String, List<String>> getFacets() {
-        return facets;
-    }
-
-    /**
-     * @param sortBy the sortBy to set
-     */
-    public void setSortBy(String sortBy) {
-        this.sortBy = sortBy;
-    }
-
-    /**
-     * @return the sortBy
-     */
-    public String getSortBy() {
-        return sortBy;
-    }
-
-    /**
-     * @param sortAscending the sortAscending to set
-     */
-    public void setSortAscending(boolean sortAscending) {
-        this.sortAscending = sortAscending;
-    }
-
-    /**
-     * @return the sortAscending
-     */
-    public boolean getSortAscending() {
-        return sortAscending;
-    }
-
-    /**
      * @param collectionId the collectionId to set
      */
     public void setCollectionId(String collectionId) {
@@ -178,140 +45,5 @@ public class SearchRequest {
      */
     public String getCollectionId() {
         return collectionId;
-    }
-
-    /**
-     * @param formatOptions the formatOptions to set. Please refer to
-     *     https://docs.constructor.com/reference/v1-search-get-search-results for details
-     */
-    public void setFormatOptions(Map<String, String> formatOptions) {
-        this.formatOptions = formatOptions;
-    }
-
-    /**
-     * @return the format options
-     */
-    public Map<String, String> getFormatOptions() {
-        return formatOptions;
-    }
-
-    /**
-     * @param hiddenFields the hiddenFields to set
-     */
-    public void setHiddenFields(List<String> hiddenFields) {
-        this.hiddenFields = hiddenFields;
-    }
-
-    /**
-     * @return the hidden fields
-     */
-    public List<String> getHiddenFields() {
-        return hiddenFields;
-    }
-
-    /**
-     * @param hiddenFacets the hiddenFacets to set
-     */
-    public void setHiddenFacets(List<String> hiddenFacets) {
-        this.hiddenFacets = hiddenFacets;
-    }
-
-    /**
-     * @return the hidden facets
-     */
-    public List<String> getHiddenFacets() {
-        return hiddenFacets;
-    }
-
-    /**
-     * @param variationsMap the variationsMap to set
-     */
-    public void setVariationsMap(VariationsMap variationsMap) {
-        this.variationsMap = variationsMap;
-    }
-
-    /**
-     * @return the variations map
-     */
-    public VariationsMap getVariationsMap() {
-        return variationsMap;
-    }
-
-    /**
-     * @param preFilterExpression the faceting expression to scope search results (JSON-encoded
-     *     query string). Please refer to
-     *     https://docs.constructor.com/reference/shared-filter-expressions
-     */
-    public void setPreFilterExpression(String preFilterExpression) {
-        this.preFilterExpression = preFilterExpression;
-    }
-
-    /**
-     * @return the prefilter expression
-     */
-    public String getPreFilterExpression() {
-        return preFilterExpression;
-    }
-
-    /**
-     * @param qsParam any parameters listed in the API documentation can be serialized into a JSON
-     *     object and parsed through this parameter. Please refer to
-     *     https://docs.constructor.com/reference/v1-search-get-search-results/
-     */
-    public void setQsParam(String qsParam) {
-        this.qsParam = qsParam;
-    }
-
-    /**
-     * @return the qs parameter
-     */
-    public String getQsParam() {
-        return qsParam;
-    }
-
-    /**
-     * @param now a unix epoch timestamp used to emulate "past" and "future" requests. Please refer
-     *     to https://docs.constructor.com/reference/v1-search-get-search-results/
-     */
-    public void setNow(String now) {
-        this.now = now;
-    }
-
-    /**
-     * @return the now parameter
-     */
-    public String getNow() {
-        return now;
-    }
-
-    /**
-     * @param offset the number of results to skip from the beginning (Can't be used together with
-     *     the 'page' parameter)
-     */
-    public void setOffset(int offset) {
-        this.offset = offset;
-    }
-
-    /**
-     * @return the offset
-     */
-    public int getOffset() {
-        return offset;
-    }
-
-    /**
-     * @param filterMatchTypes the filterMatchTypes to set. Please refer to
-     *     https://docs.constructor.com/reference/v1-search-get-search-results for details
-     *     Possible values 'all', 'any' or 'none'
-     */
-    public void setFilterMatchTypes(Map<String, String> filterMatchTypes) {
-        this.filterMatchTypes = filterMatchTypes;
-    }
-
-    /**
-     * @return the filterMatchTypes
-     */
-    public Map<String, String> getFilterMatchTypes() {
-        return filterMatchTypes;
     }
 }


### PR DESCRIPTION
Closes issue https://github.com/Constructor-io/constructorio-java/issues/188

To be able to factorize code between search and browse common request parameters

I didn't want the object to be called only `BaseRequest` so I chose `BrowseSearchBaseRequest` but not totally convinced